### PR TITLE
Feature/component buildout

### DIFF
--- a/gui/src/App.js
+++ b/gui/src/App.js
@@ -14,6 +14,8 @@ import { apiUrl } from './utils.js';
 export function App() {
 	//this creates a variable 'status', initializes its value to null, 
 	//and says that to change the state value of 'status' we use setStatus
+	//we'll pass 'status' to Home.js and Status.js as a prop
+	//maybe it should be stored in a reducer instead?
 	const [status, setStatus] = useState();
 	//this just sends a get request(?) to 'http://localhost(or whatever the user has):5000/status'
 	const getStatus = () => {

--- a/gui/src/App.js
+++ b/gui/src/App.js
@@ -1,15 +1,16 @@
 import React, { useState, useEffect } from 'react';
-// import { Switch, Route, Link } from 'react-router-dom';
 import { Switch, Route } from 'react-router-dom';
 // import { Icon, Menu, Segment } from 'semantic-ui-react';
 import './style.css';
-// import { Header } from './Header.js';
+
 import { Home } from './Home.js';
 import { Recipes } from './Recipes.js';
 import { RecipeDetails } from './RecipeDetails.js';
+import { ReactionHistory } from './ReactionHistory'
 import { Tests } from './Tests.js';
 import { Settings } from './Settings.js';
 import { Status } from './Status.js';
+
 import { apiUrl } from './utils.js';
 
 export function App() {
@@ -50,6 +51,10 @@ export function App() {
 
 				<Route path='/recipes/:recipeName'>
 					<RecipeDetails />
+				</Route>
+
+				<Route path='/reaction-history'>
+					<ReactionHistory />
 				</Route>
 
 				<Route path='/tests'>

--- a/gui/src/App.js
+++ b/gui/src/App.js
@@ -6,6 +6,7 @@ import './style.css';
 // import { Header } from './Header.js';
 import { Home } from './Home.js';
 import { Recipes } from './Recipes.js';
+import { RecipeDetails } from './RecipeDetails.js';
 import { Tests } from './Tests.js';
 import { Settings } from './Settings.js';
 import { Status } from './Status.js';
@@ -43,8 +44,12 @@ export function App() {
 					<Home status={status} />
 				</Route>
 
-				<Route path='/recipes'>
+				<Route exact path='/recipes'>
 					<Recipes />
+				</Route>
+
+				<Route path='/recipes/:recipeName'>
+					<RecipeDetails />
 				</Route>
 
 				<Route path='/tests'>

--- a/gui/src/App.js
+++ b/gui/src/App.js
@@ -12,23 +12,28 @@ import { Status } from './Status.js';
 import { apiUrl } from './utils.js';
 
 export function App() {
+	//this creates a variable 'status', initializes its value to null, 
+	//and says that to change the state value of 'status' we use setStatus
 	const [status, setStatus] = useState();
-
+	//this just sends a get request(?) to 'http://localhost(or whatever the user has):5000/status'
 	const getStatus = () => {
 		fetch(apiUrl + 'status')
+			//once it gets a response from the server, it turns it into object 
 			.then(response => response.json())
+			//and updates the state value of 'status' to be the value of the data it gets back
 			.then(data => setStatus(data));
 	};
-
+	//this requests the status every 1000 milliseconds (1 second)
 	useEffect(() => {
 		const interval = setInterval(() => {
 			getStatus();
 		}, 1000);
 		return () => clearInterval(interval);
 	}, []);
-
+	//i'm a little confused why this happens every time status is updated
 	console.log(status);
-
+	//these are the routes. is it in a div instead of Router for any reason?
+	//^i think becuase in style.css it sets the maybe-size of the screen
 	return (
 		<div className='lcd-wrapper'>
 			<Switch>

--- a/gui/src/App.js
+++ b/gui/src/App.js
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import { Switch, Route } from 'react-router-dom';
-// import { Icon, Menu, Segment } from 'semantic-ui-react';
 import './style.css';
 
 import { Home } from './Home.js';
@@ -14,28 +13,19 @@ import { Status } from './Status.js';
 import { apiUrl } from './utils.js';
 
 export function App() {
-	//this creates a variable 'status', initializes its value to null, 
-	//and says that to change the state value of 'status' we use setStatus
-	//we'll pass 'status' to Home.js and Status.js as a prop
-	//maybe it should be stored in a reducer instead?
 	const [status, setStatus] = useState();
-	//this just sends a get request(?) to 'http://localhost(or whatever the user has):5000/status'
 	const getStatus = () => {
 		fetch(apiUrl + 'status')
-			//once it gets a response from the server, it turns it into object 
 			.then(response => response.json())
-			//and updates the state value of 'status' to be the value of the data it gets back
 			.then(data => setStatus(data));
 	};
-	//this requests the status every 1000 milliseconds (1 second)
 	useEffect(() => {
 		const interval = setInterval(() => {
 			getStatus();
 		}, 1000);
 		return () => clearInterval(interval);
 	}, []);
-	//i'm a little confused why this happens every time status is updated
-	console.log(status);
+	console.log("status: ", status);
 	//these are the routes. is it in a div instead of Router for any reason?
 	//^i think becuase in style.css it sets the maybe-size of the screen
 	return (

--- a/gui/src/App.js
+++ b/gui/src/App.js
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from 'react';
-import { Switch, Route, Link } from 'react-router-dom';
-import { Icon, Menu, Segment } from 'semantic-ui-react';
+// import { Switch, Route, Link } from 'react-router-dom';
+import { Switch, Route } from 'react-router-dom';
+// import { Icon, Menu, Segment } from 'semantic-ui-react';
 import './style.css';
-import { Header } from './Header.js';
+// import { Header } from './Header.js';
 import { Home } from './Home.js';
 import { Recipes } from './Recipes.js';
 import { Tests } from './Tests.js';

--- a/gui/src/Header.js
+++ b/gui/src/Header.js
@@ -1,7 +1,5 @@
 import React from 'react';
-// import { Switch, Route, Link, useHistory, useRouteMatch } from 'react-router-dom';
 import { Link, useHistory, useRouteMatch } from 'react-router-dom';
-// import { Icon, Menu, Segment } from 'semantic-ui-react';
 import { Icon, Menu } from 'semantic-ui-react';
 
 export function Header(props) {
@@ -25,7 +23,7 @@ export function Header(props) {
 
 				<Menu.Item
 					icon
-					position='right'
+					position='center'
 					as={Link}
 					to='/settings'
 				>

--- a/gui/src/Header.js
+++ b/gui/src/Header.js
@@ -1,6 +1,8 @@
 import React from 'react';
-import { Switch, Route, Link, useHistory, useRouteMatch } from 'react-router-dom';
-import { Icon, Menu, Segment } from 'semantic-ui-react';
+// import { Switch, Route, Link, useHistory, useRouteMatch } from 'react-router-dom';
+import { Link, useHistory, useRouteMatch } from 'react-router-dom';
+// import { Icon, Menu, Segment } from 'semantic-ui-react';
+import { Icon, Menu } from 'semantic-ui-react';
 
 export function Header(props) {
 	const history = useHistory();

--- a/gui/src/Header.js
+++ b/gui/src/Header.js
@@ -27,6 +27,15 @@ export function Header(props) {
 					icon
 					position='right'
 					as={Link}
+					to='/settings'
+				>
+					<Icon name='setting' />
+				</Menu.Item>
+
+				<Menu.Item
+					icon
+					position='right'
+					as={Link}
 					to='/'
 				>
 					<Icon name='home' />

--- a/gui/src/Home.js
+++ b/gui/src/Home.js
@@ -33,8 +33,8 @@ export function Home(props) {
 					<Button as={Link} to='/recipes'>Start a Reaction</Button>
 				}
 				{/* should this be a verb like 'view recipes' (as opposed to choose one) */}
-				<Button as={Link} to='/nothinghereyet'>
-					Just View Recipes, Don't Start Reaction
+				<Button as={Link} to='/recipes'>
+					Recipes
 				</Button>
 
 				{/* should hardware be test-able mid recipe? maybe there

--- a/gui/src/Home.js
+++ b/gui/src/Home.js
@@ -1,13 +1,10 @@
 import React from 'react';
-// import { Switch, Route, Link } from 'react-router-dom';
 import { Link } from 'react-router-dom';
-// import { Button, Icon, Menu, Segment } from 'semantic-ui-react';
 import { Button } from 'semantic-ui-react';
 import './style.css';
 import { Header } from './Header.js';
 
 export function Home(props) {
-	//this is the same as saying status = props.status
 	const { status } = props;
 
 	return (
@@ -37,14 +34,14 @@ export function Home(props) {
 					Reaction History
 				</Button>
 
-				{/* should this be a verb like 'view recipes' (as opposed to choose one) */}
+				{/* should this be a verb like 'view recipes' (as opposed to choose one to start) */}
 				<Button as={Link} to='/recipes'>
 					Recipes
 				</Button>
 
 				{/* should hardware be test-able mid recipe? maybe there
 				should be one home screen for if there is a recipe going,
-				and one for if there isn't? */}
+				and one for if there isn't? or tests could be inside settings? */}
 				<Button as={Link} to='/tests'>
 					Test Hardware
 				</Button>

--- a/gui/src/Home.js
+++ b/gui/src/Home.js
@@ -7,6 +7,7 @@ import './style.css';
 import { Header } from './Header.js';
 
 export function Home(props) {
+	//this is the same as saying status = props.status
 	const { status } = props;
 
 	return (
@@ -14,20 +15,37 @@ export function Home(props) {
 			<Header>Home</Header>
 
 			<div className='button-menu'>
-				{status && status.recipe &&
-					<Button as={Link} to='/status'>
-						{status.recipe.toUpperCase()} Status
-					</Button>
+				{(status && status.recipe) ?
+					//check if there's a recipe in progress.
+					//if there is, give a link to see its status
+					//if not, offer option to start reaction
+					//doing this ternary operator leads to it showing the
+					//second option for up to a second before the server
+					//comes back with the status.
+					//is this a case for useEffect?
+					<div>
+						<p>{status.recipe} recipe in progress.</p>
+						<Button as={Link} to='/status'>
+							see {status.recipe.toUpperCase()} Status
+						</Button>
+					</div>
+					:
+					<Button>start a reaction</Button>
 				}
-
+				{/* should this be a verb like 'view recipes' (as opposed to choose one) */}
 				<Button as={Link} to='/recipes'>
 					Recipes
 				</Button>
 
+				{/* should hardware be test-able mid recipe? maybe there
+				should be one home screen for if there is a recipe going,
+				and one for if there isn't? */}
 				<Button as={Link} to='/tests'>
-					Hardware Tests
+					Test Hardware
 				</Button>
 
+				{/* same question- should settings be change-able mid recipe? 
+				or just viewable? */}
 				<Button as={Link} to='/settings'>
 					Settings
 				</Button>

--- a/gui/src/Home.js
+++ b/gui/src/Home.js
@@ -32,6 +32,11 @@ export function Home(props) {
 					:
 					<Button as={Link} to='/recipes'>Start a Reaction</Button>
 				}
+				
+				<Button as={Link} to='/reaction-history'>
+					Reaction History
+				</Button>
+
 				{/* should this be a verb like 'view recipes' (as opposed to choose one) */}
 				<Button as={Link} to='/recipes'>
 					Recipes

--- a/gui/src/Home.js
+++ b/gui/src/Home.js
@@ -1,6 +1,8 @@
 import React from 'react';
-import { Switch, Route, Link } from 'react-router-dom';
-import { Button, Icon, Menu, Segment } from 'semantic-ui-react';
+// import { Switch, Route, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+// import { Button, Icon, Menu, Segment } from 'semantic-ui-react';
+import { Button } from 'semantic-ui-react';
 import './style.css';
 import { Header } from './Header.js';
 

--- a/gui/src/Home.js
+++ b/gui/src/Home.js
@@ -16,25 +16,25 @@ export function Home(props) {
 
 			<div className='button-menu'>
 				{(status && status.recipe) ?
-					//check if there's a recipe in progress.
-					//if there is, give a link to see its status
+					//if there's a recipe in progress, give a link to see its status
 					//if not, offer option to start reaction
 					//doing this ternary operator leads to it showing the
 					//second option for up to a second before the server
 					//comes back with the status.
 					//is this a case for useEffect?
 					<div>
-						<p>{status.recipe} recipe in progress.</p>
+						<p>{status.recipe} reaction in progress.</p>
 						<Button as={Link} to='/status'>
-							see {status.recipe.toUpperCase()} Status
+							Resume {status.recipe.toUpperCase()} Reaction
+							{/* maybe this would be a good place to preview next step? */}
 						</Button>
 					</div>
 					:
-					<Button>start a reaction</Button>
+					<Button as={Link} to='/recipes'>Start a Reaction</Button>
 				}
 				{/* should this be a verb like 'view recipes' (as opposed to choose one) */}
-				<Button as={Link} to='/recipes'>
-					Recipes
+				<Button as={Link} to='/nothinghereyet'>
+					Just View Recipes, Don't Start Reaction
 				</Button>
 
 				{/* should hardware be test-able mid recipe? maybe there

--- a/gui/src/Home.js
+++ b/gui/src/Home.js
@@ -48,12 +48,6 @@ export function Home(props) {
 				<Button as={Link} to='/tests'>
 					Test Hardware
 				</Button>
-
-				{/* same question- should settings be change-able mid recipe? 
-				or just viewable? */}
-				<Button as={Link} to='/settings'>
-					Settings
-				</Button>
 			</div>
 		</div>
 	);

--- a/gui/src/ReactionHistory.js
+++ b/gui/src/ReactionHistory.js
@@ -1,0 +1,14 @@
+import React from 'react';
+// import { Button, Icon, Menu, Segment } from 'semantic-ui-react';
+
+import { Header } from './Header.js';
+
+export function ReactionHistory() {
+    return (
+        <div>
+            <Header>Reaction History</Header>
+
+            <p>Reaction History page here...</p>
+        </div>
+    );
+}

--- a/gui/src/RecipeDetails.js
+++ b/gui/src/RecipeDetails.js
@@ -1,0 +1,44 @@
+import React, { useState, useEffect } from 'react';
+// import { Switch, Route, Link, useHistory } from 'react-router-dom';
+import { useParams} from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
+// import { Button, Icon, Menu, Segment } from 'semantic-ui-react';
+import { Button } from 'semantic-ui-react';
+
+import './style.css';
+import { Header } from './Header.js';
+import { apiUrl } from './utils.js';
+
+export function RecipeDetails() {
+    const [recipies, setRecipies] = useState(false);
+    const history = useHistory();
+    const { recipeName } = useParams();
+
+    // get specific recipe details based on param(recipe name)? or would it be passed thru?
+    // useEffect(() => {
+    //     fetch(apiUrl + 'list')
+    //         .then(response => response.json())
+    //         .then(data => setRecipies(data));
+    // }, []);
+
+    const startRecipe = (name) => {
+    	fetch(apiUrl + 'start/' + name)
+    		.then(response => response.json())
+    		.then(data => history.push('/status'));
+    };
+
+    console.log(recipies);
+
+    return (
+        <div>
+            <Header>Recipe Details</Header>
+            <h1>{ recipeName }</h1>
+            <p>more details would go here</p>
+            <p>would they come from props? redux store?</p>
+            <Button onClick={() => startRecipe(recipeName)}>
+                Start A Reaction Using This Recipe
+            </Button>
+            <p>this button should only be clickable if there isn't a reaction going</p>
+        </div>
+    );
+}

--- a/gui/src/RecipeDetails.js
+++ b/gui/src/RecipeDetails.js
@@ -1,25 +1,22 @@
 import React, { useState, useEffect } from 'react';
-// import { Switch, Route, Link, useHistory } from 'react-router-dom';
 import { useParams} from 'react-router-dom';
 import { useHistory } from 'react-router-dom';
-// import { Button, Icon, Menu, Segment } from 'semantic-ui-react';
 import { Button } from 'semantic-ui-react';
 
-import './style.css';
 import { Header } from './Header.js';
 import { apiUrl } from './utils.js';
 
 export function RecipeDetails() {
-    const [recipies, setRecipies] = useState(false);
+    const [recipeDetails, setRecipeDetails] = useState(false);
     const history = useHistory();
     const { recipeName } = useParams();
 
-    // get specific recipe details based on param(recipe name)? or would it be passed thru?
-    // useEffect(() => {
-    //     fetch(apiUrl + 'list')
-    //         .then(response => response.json())
-    //         .then(data => setRecipies(data));
-    // }, []);
+    // fetch recipe details, such as steps, ingredients, time
+    useEffect(() => {
+        fetch(apiUrl + '___________')
+            .then(response => response.json())
+            .then(data => setRecipeDetails(data));
+    }, []);
 
     const startRecipe = (name) => {
     	fetch(apiUrl + 'start/' + name)
@@ -27,18 +24,47 @@ export function RecipeDetails() {
     		.then(data => history.push('/status'));
     };
 
-    console.log(recipies);
+    console.log("recipe details:", recipeDetails);
 
     return (
         <div>
             <Header>Recipe Details</Header>
             <h1>{ recipeName }</h1>
-            <p>more details would go here</p>
-            <p>would they come from props? redux store?</p>
+                {/* 
+                display details of the selected recipe.
+                having the fetch be based on the url makes it so that if a user visits 
+                the address it'll get the right info- but is that even relevant with the hardware being used?
+                If no one's ever going to visit .../recipes/this-specific-recipe other than by clicking on 
+                the name in Recipes.js, then the fetch could just come from the "see details" button 
+                in Recipes and be provided to this component with props or with a redux store.
+                */}
+
+                {recipeDetails ?
+                    // might make sense to have individual "Materials", "Time", "Steps" components 
+                    // if they might be reused outside of this RecipeDetails component (like on a confirmation "are you ready to start this for real?" screen?)
+                    <>
+                    <h2>Materials Needed:</h2>
+                        <ul>
+                            {/* map out materials */}
+                        </ul>
+                    <h2>Time Needed:</h2>
+                        {/* total time? which steps are time sensitive and how long between them? */}
+                    <h2>Steps:</h2>
+                        <ul>
+                            {/* map out steps */}
+                            {/* maybe "Step.js" component if it'll look the same as when a reaction's in progress */}
+                        </ul>
+                    </>
+                    :
+                    <p>loading...</p>
+                }
+
+            {/* this button should only be clickable/present if there isn't a reaction going, 
+            meaning this component needs to know status, either from props passed to it 
+            or from a redux store store.*/}
             <Button onClick={() => startRecipe(recipeName)}>
                 Start A Reaction Using This Recipe
             </Button>
-            <p>this button should only be clickable if there isn't a reaction going</p>
         </div>
     );
 }

--- a/gui/src/Recipes.js
+++ b/gui/src/Recipes.js
@@ -25,11 +25,12 @@ export function Recipes() {
 			.then(data => setRecipies(data));
 	}, []);
 
-	// console.log(recipies);
+	console.log("recipes:", recipies);
 
 	return (
 		<div>
-			<Header>Recipes</Header>
+			<Header>Recipes</Header> 
+			{/* this could be "choose a recipe" if in 'I want to start a reaction' mode */}
 
 			{recipies ?
 				<div className='button-menu'>

--- a/gui/src/Recipes.js
+++ b/gui/src/Recipes.js
@@ -30,7 +30,6 @@ export function Recipes() {
 	return (
 		<div>
 			<Header>Recipes</Header> 
-			{/* this could be "choose a recipe" if in 'I want to start a reaction' mode */}
 
 			{recipies ?
 				<div className='button-menu'>

--- a/gui/src/Recipes.js
+++ b/gui/src/Recipes.js
@@ -18,11 +18,11 @@ export function Recipes() {
 			.then(data => setRecipies(data));
 	}, []);
 
-	const startRecipe = (name) => {
-		fetch(apiUrl + 'start/' + name)
-			.then(response => response.json())
-			.then(data => history.push('/status'));
-	};
+	// const startRecipe = (name) => {
+	// 	fetch(apiUrl + 'start/' + name)
+	// 		.then(response => response.json())
+	// 		.then(data => history.push('/status'));
+	// };
 
 	console.log(recipies);
 
@@ -32,9 +32,10 @@ export function Recipes() {
 
 			{recipies ?
 				<div className='button-menu'>
-					{recipies.map(x =>
-						<Button key={x} onClick={() => startRecipe(x)}>
-							{x.toUpperCase()}
+					{recipies.map(recipe =>
+						// click on recipe to view details
+						<Button key={recipe} onClick={() => history.push(`/recipes/${recipe}`)}>
+							{recipe.toUpperCase()} (click to view details)
 						</Button>
 					)}
 				</div>

--- a/gui/src/Recipes.js
+++ b/gui/src/Recipes.js
@@ -1,30 +1,31 @@
 import React, { useState, useEffect } from 'react';
-// import { Switch, Route, Link, useHistory } from 'react-router-dom';
 import { useHistory } from 'react-router-dom';
-// import { Button, Icon, Menu, Segment } from 'semantic-ui-react';
 import { Button} from 'semantic-ui-react';
 
-import './style.css';
 import { Header } from './Header.js';
 import { apiUrl } from './utils.js';
+
+// This component, Recipes.js, requests a list of recipe names to display on the screen
+// It seems like App.js could also request this list and make it available to Recipes.js with redux. 
+
+// It makes sense to use this component whenever the user wants to see a list of all the recipes (obviously)
+// which would either be before choosing a reaction to run, or just browsing
+// If they select a recipe when they're in browsing mode, they probably want to see a list of materials and steps.
+// If they select a recipe when they're in 'I want to run a reaction' mode, they probably want a quick summary/confirmation before proceeding
+// These two modes could be differentiated based on parent component passing props to this component
+// or in the redux store with a reducer 
 
 export function Recipes() {
 	const [recipies, setRecipies] = useState(false);
 	const history = useHistory();
 
 	useEffect(() => {
-		fetch(apiUrl + 'list')
+		fetch(apiUrl + 'list')//this route returns an array with all the names ex: ['recipe1',recipe2']
 			.then(response => response.json())
 			.then(data => setRecipies(data));
 	}, []);
 
-	// const startRecipe = (name) => {
-	// 	fetch(apiUrl + 'start/' + name)
-	// 		.then(response => response.json())
-	// 		.then(data => history.push('/status'));
-	// };
-
-	console.log(recipies);
+	// console.log(recipies);
 
 	return (
 		<div>

--- a/gui/src/Recipes.js
+++ b/gui/src/Recipes.js
@@ -1,6 +1,9 @@
 import React, { useState, useEffect } from 'react';
-import { Switch, Route, Link, useHistory } from 'react-router-dom';
-import { Button, Icon, Menu, Segment } from 'semantic-ui-react';
+// import { Switch, Route, Link, useHistory } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
+// import { Button, Icon, Menu, Segment } from 'semantic-ui-react';
+import { Button} from 'semantic-ui-react';
+
 import './style.css';
 import { Header } from './Header.js';
 import { apiUrl } from './utils.js';

--- a/gui/src/Settings.js
+++ b/gui/src/Settings.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Switch, Route, Link } from 'react-router-dom';
-import { Button, Icon, Menu, Segment } from 'semantic-ui-react';
+// import { Switch, Route, Link } from 'react-router-dom';
+// import { Button, Icon, Menu, Segment } from 'semantic-ui-react';
 import './style.css';
 import { Header } from './Header.js';
 

--- a/gui/src/Settings.js
+++ b/gui/src/Settings.js
@@ -1,7 +1,6 @@
 import React from 'react';
-// import { Switch, Route, Link } from 'react-router-dom';
 // import { Button, Icon, Menu, Segment } from 'semantic-ui-react';
-import './style.css';
+
 import { Header } from './Header.js';
 
 export function Settings() {

--- a/gui/src/Status.js
+++ b/gui/src/Status.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import { Switch, Route, Link } from 'react-router-dom';
-import { Button, Icon, Menu, Segment } from 'semantic-ui-react';
+// import { Switch, Route, Link } from 'react-router-dom';
+// import { Button, Icon, Menu, Segment } from 'semantic-ui-react';
+import { Button } from 'semantic-ui-react';
 import './style.css';
 import { Header } from './Header.js';
 import { apiUrl } from './utils.js';

--- a/gui/src/Status.js
+++ b/gui/src/Status.js
@@ -1,8 +1,6 @@
 import React, { useState, useEffect } from 'react';
-// import { Switch, Route, Link } from 'react-router-dom';
-// import { Button, Icon, Menu, Segment } from 'semantic-ui-react';
 import { Button } from 'semantic-ui-react';
-import './style.css';
+
 import { Header } from './Header.js';
 import { apiUrl } from './utils.js';
 

--- a/gui/src/Tests.js
+++ b/gui/src/Tests.js
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
-import { Switch, Route, Link } from 'react-router-dom';
-import { Button, Icon, Menu, Segment } from 'semantic-ui-react';
+// import { Switch, Route, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+// import { Button, Icon, Menu, Segment } from 'semantic-ui-react';
+import { Button } from 'semantic-ui-react';
 import './style.css';
 import { Header } from './Header.js';
 import { apiUrl } from './utils.js';


### PR DESCRIPTION
A much larger PR than I like to make normally but this felt like the first decent stopping point.

### Overview:

- Modified home component a good amount to be more in line with the mockup and intuitive UI choices. 
    - Moved settings to header
    - Gave the options to start a reaction, view history, or view recipes. 
    - Not attached to existence or placement any of the above. It all would depend on UX goals. 

- Created 'Recipe Details' and 'Reaction History' components (with nothing happening in them yet) and paths/buttons to them

- Removed unused imports to make things less cluttered, added some editorial comments mostly about redux or where components might be used

- pretty much left 'Status' and Testing-related components alone 


### Next:

- Add Redux? Things like ‘status’ or ‘current recipe’ or ‘history’ could be accessible by multiple components w/o passing down through props.

- Get comfortable with the API/python and get recipe details showing up

- acquire hardware for myself for better testing