### PR TITLE
Fixed bug where stopping the recipe doesn't stop the celery task

### DIFF
--- a/backend/recipes/base.py
+++ b/backend/recipes/base.py
@@ -108,7 +108,6 @@ class Recipe:
         """
         Stop running the recipe.
 
-        TODO: figure out how to stop any running celery tasks
         :return:
         None
         """
@@ -119,6 +118,7 @@ class Recipe:
         self.time = ''
         hardware.turnHeaterOff()
         hardware.turnCoolerOff()
+        celery.stopTask()
 
     def getStatus(self):
         """

--- a/backend/recipes/celery.py
+++ b/backend/recipes/celery.py
@@ -153,4 +153,13 @@ def isTaskComplete():
 
     return True
 
+def stopTask():
+    """
+    Stop the currently running task.
+    :return:
+        None
+    """
+    if result is not None:
+        result.revoke(terminate=True)
+
 


### PR DESCRIPTION
## TL;DR
Made celery tasks actually stop executing when the user stops the recipe.

## What
What is affected by this PR?
- [ ] API
- [ ] GUI
- [ ] Hardware Integration
- [ ] OS/Deployment
- [ ] Documentation
- [X] Other (please describe in notes)

## Testing
How was this tested?
- [ ] Locally Virtualized
- [X] Raspberry Pi
- [ ] With Hardware
- [ ] Other (please describe in notes)

## Notes

Should we add a category to the PR template for backend generally? Because that's all this effects.