### PR TITLE
Add environment variables

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1,35 +1,45 @@
+from os import environ
 """
 This is the config file. See the comments for each option.
 """
 
+# The Host and port that the backend API is running on
+apiHost = environ.get("API_HOST", 'localhost')  
+apiPort = environ.get("API_PORT", 8081)  
+
 # The URL used by the celery backend to update the state in the app.
-localUrl = 'http://localhost:8081/'
+localUrl = 'http://%s:%s' % (apiHost, apiPort)
 
 # Which hardware implementation to use. Currently only 'real' or 'simulation' are supported.
 #hardwarePackage = 'real'
-hardwarePackage = 'simulation'
-hardwareSpeedup = 10
+hardwarePackage = environ.get("HARDWARE_PACKAGE", 'simulation')  
+hardwareSpeedup = environ.get("HARDWARE_SPEEDUP", 10)  
 
 # port for temperature sensor... eventually we want to automatically detect this
-hardwareTempPort = '/dev/ttyUSB1'
-hardwareHeaterPin = 19
-hardwareCoolearPin = 26
-hardwareStirrerPin = 20
+hardwareTempPort = environ.get("TEMP_PORT", '/dev/ttyUSB1')
+hardwareHeaterPin = environ.get("HEATER_PIN", 19)  
+hardwareCoolearPin = environ.get("COOLER_PIN", 26)
+hardwareStirrerPin = environ.get("STIRRER_PIN", 20)
 
 # port for Arduino... again need to auto-detect as the temp sensor may or may not be detected first
-hardwareArduinoPort = '/dev/ttyUSB0'
+hardwareArduinoPort = environ.get("ARDUINO_PORT", '/dev/ttyUSB0') 
 hardwarePumpAGcode1ml = b'G91X1.1\n'
 hardwarePumpAGcodeRetract = b'G91X-0.25\n'
 hardwarePumpBGcode1ml = b'G91Y1.1\n'
 hardwarePumpBGcodeRetract = b'G91Y-0.25\n'
 
 # Where the recipe files are located. You should never need to change this.
-recipesPackage = 'recipes.files'
+recipesPackage = environ.get("RECIPES_PACKAGE", 'recipes.files')  
 
 # Celery configuration. You should never need to change this.
-celeryMode = 'real'     # 'real' and 'test' are supported. In 'test' mode
-                        # it doesn't actually send the requests to the celery
-                        # server it just runs them in the same thread. This is
-                        # only useful for testing
-celeryBackend = 'redis://redis:6379/0'
-celeryBroker = 'redis://redis:6379/0'
+# 'real' and 'test' are supported. In 'test' mode
+# it doesn't actually send the requests to the celery
+# server it just runs them in the same thread. This is
+# only useful for testing
+celeryMode = environ.get("CELERY_MODE", 'real')     
+
+redisHost = environ.get("REDIS_HOST", 'localhost')  
+redisPort = environ.get("REDIS_PORT", 6379)  
+
+celeryBackend = 'redis://%s:%s/0' % (redisHost, redisPort)
+celeryBroker = 'redis://%s:%s/0' % (redisHost, redisPort)

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,4 +5,4 @@ from api import app
 import config
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=8081, use_reloader=True)
+    app.run(host='0.0.0.0', port=config.apiPort, use_reloader=True)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,10 @@ services:
     entrypoint: celery
     command: -A recipes worker --loglevel=INFO
     environment:
-      - CACHE_REDIS_HOST="redis"
+      CACHE_REDIS_HOST: "redis"
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      API_HOST: api
     volumes:
       - ./backend:/app
     links:


### PR DESCRIPTION
## TL;DR
Added ability to configure most variables in the configuration file using environment variables. 

Also used these to configure the docker worker to fix a bug where when tasks were completed they weren't signalling the API to move on to the next task since it was trying to go to localhost:8081 instead of api:8081. This only occurred if the web gui wasn't open since the GUI polling for status updates also triggers moving on to the next task.

## What
What is affected by this PR?
- [ ] API
- [ ] GUI
- [ ] Hardware Integration
- [X] OS/Deployment
- [ ] Documentation
- [ ] Other (please describe in notes)

## Testing
How was this tested?
- [ ] Locally Virtualized
- [ ] Raspberry Pi
- [ ] With Hardware
- [ ] Other (please describe in notes)

## Notes
How was your day?