### PR TITLE
Fix race condition on task completion

### DIFF
--- a/backend/recipes/base.py
+++ b/backend/recipes/base.py
@@ -75,6 +75,8 @@ plan object
 
 from recipes import celery
 import hardware
+import threading
+
 
 
 class Recipe:
@@ -85,6 +87,8 @@ class Recipe:
     icon = ''
     time = ''
     currentRecipe = None
+    mutex = threading.Lock()
+
     def __init__(self, plan):
         """
         Constructor. Saves the plan.
@@ -163,17 +167,17 @@ class Recipe:
         object
             Same as getStatus()
         """
+        self.mutex.acquire()
         if self.status == 'running':
             if celery.isTaskComplete():
                 currentStep = self.plan['steps'][self.step]
                 if('done' in currentStep) and (currentStep['done'] == True):
                     self.stop()
-                    return self.getStatus()
                 else:
                     if 'next' in currentStep:
                         self.step = currentStep['next']
                         self.runStep()
-
+        self.mutex.release()
         return self.getStatus()
 
     def selectOption(self, optionValue):


### PR DESCRIPTION
## TL;DR
Fixed race condition when tasks were completed, recipe could end up in a variety of undefined states if multiple updateStatus requests arrived in a close enough time span. Surprisingly common, happened to me 2-3 times normally and was easy to reproduce by opening like 10 different tabs of the frontend at once.

## What
What is affected by this PR?
- [ ] API
- [ ] GUI
- [ ] Hardware Integration
- [ ] OS/Deployment
- [ ] Documentation
- [X] Other (please describe in notes)

## Testing
How was this tested?
- [ ] Locally Virtualized
- [X] Raspberry Pi
- [ ] With Hardware
- [ ] Other (please describe in notes)

## Notes
How was your day?