### PR TITLE
Added github action for testing container build on PRs

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -1,0 +1,12 @@
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  docker_build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build docker containers
+        run: docker-compose build


### PR DESCRIPTION
## TL;DR
Added a github action that tries to build the docker containers on all pull requests. Will let us automatically validate that PR's don't break the docker containers. Currently it is failing because #92 needed to add additional dependencies to the API container, the fix for that is in #94.

## What
What is affected by this PR?
- [ ] API
- [ ] GUI
- [ ] Hardware Integration
- [ ] OS/Deployment
- [ ] Documentation
- [X] Other (please describe in notes)

## Testing
How was this tested?
- [ ] Locally Virtualized
- [ ] Raspberry Pi
- [ ] With Hardware
- [X] Other (please describe in notes)

## Notes
Effects PRs.