### PR TITLE
Converted step completion time to a timestamp from a duration

### DIFF
--- a/backend/recipes/__init__.py
+++ b/backend/recipes/__init__.py
@@ -112,6 +112,9 @@ def status():
                     A system error has occurred.
         icon
             The icon to show in the UI. See StatusIcon.jsx for supported icons.
+        stepCompletionTime
+            An ISO date string for when the current step is expected to be completed,
+            or null if unknown. 
     """
     message = {
         'status': 'idle',
@@ -119,6 +122,7 @@ def status():
         'step': -1,
         'message': None,
         'options': [],
+        'stepCompletionTime': None
     }
 
     if state.currentRecipe == None:
@@ -131,7 +135,7 @@ def status():
     message['message'] = recipeMessage['message']
     message['options'] = recipeMessage['options']
     message['icon'] = recipeMessage['icon']
-    message['time'] = recipeMessage['time']
+    message['stepCompletionTime'] = recipeMessage['stepCompletionTime']
 
     return message
 

--- a/gui/src/pages/Status.jsx
+++ b/gui/src/pages/Status.jsx
@@ -11,12 +11,7 @@ export function Status(props) {
   const [loading, setLoading] = useState(false)
   const [currentStep, setCurrentStep] = useState(-1)
   const [stepTime, setStepTime] = useState()
-  const [elapsedTime, setElapsedTime] = useState(0)
   const history = useHistory()
-
-  useInterval(() => {
-    setElapsedTime(elapsedTime + 1)
-  }, 1000)
 
   const handleOptionButtonClick = option => {
     if (loading) return
@@ -40,9 +35,8 @@ export function Status(props) {
     setLoading(false)
     if (status && status.step !== currentStep) {
       setCurrentStep(status.step)
-      setElapsedTime(0)
-      if (status.time && status.time !== '') {
-        setStepTime(status.time)
+      if (status.stepCompletionTime) {
+        setStepTime(new Date(status.stepCompletionTime))
         return
       }
       setStepTime(null)
@@ -60,7 +54,9 @@ export function Status(props) {
               <Container textAlign="center">
                 <StatusIcon icon={status.icon} />
                 <p className="status-message">{status.message}</p>
-                {stepTime && <p className="status-message">{`${humanizeDuration((stepTime - elapsedTime) * 1000)}`}</p>}
+                {stepTime && <p className="status-message">
+                    {`${humanizeDuration(stepTime - new Date(), { round: true })}`}
+                  </p>}
               </Container>
             </Grid.Column>
             <Grid.Column className="status-page-menu">

--- a/gui/src/styles/app.css
+++ b/gui/src/styles/app.css
@@ -83,6 +83,7 @@ body {
 
 .status-page .status-message {
   font-size: 20px;
+  margin-bottom: 0.5rem;
 }
 /* TODO: Break this out into separate files */
 /* Pages */


### PR DESCRIPTION
## TL;DR
Converted the time field in Recipe to be a timestamp of when the step will complete instead of a duration of how long the step will execute for. Fixes an issue where if the user refreshes the status page or leaves and comes back mid step the countdown of time remaining is wrong.

## What
What is affected by this PR?
- [X] API
- [X] GUI
- [ ] Hardware Integration
- [ ] OS/Deployment
- [X] Documentation
- [ ] Other (please describe in notes)

## Testing
How was this tested?
- [ ] Locally Virtualized
- [X] Raspberry Pi
- [ ] With Hardware
- [ ] Other (please describe in notes)

## Notes
How was your day?
7/10