### PR TITLE
Split out heater pins, switched relay on/off values

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -17,6 +17,7 @@ hardwareSpeedup = environ.get("HARDWARE_SPEEDUP", 10)
 
 # port for temperature sensor... eventually we want to automatically detect this
 hardwareTempPort = environ.get("TEMP_PORT", '/dev/ttyUSB1')
+hardwareHeaterPumpPin = environ.get("HEATER_PUMP_PIN", 16)  
 hardwareHeaterPin = environ.get("HEATER_PIN", 19)  
 hardwareCoolearPin = environ.get("COOLER_PIN", 26)
 hardwareStirrerPin = environ.get("STIRRER_PIN", 20)

--- a/backend/hardware/real/__init__.py
+++ b/backend/hardware/real/__init__.py
@@ -29,8 +29,8 @@ initialized = False
 tempSer = None
 grblSer = None
 
-RELAY_ON = False
-RELAY_OFF = True
+RELAY_ON = True
+RELAY_OFF = False
 
 
 def initHardware():

--- a/backend/hardware/real/__init__.py
+++ b/backend/hardware/real/__init__.py
@@ -52,10 +52,12 @@ def initHardware():
         # Init relays
         GPIO.setmode(GPIO.BCM)
         GPIO.setwarnings(False)
+        GPIO.setup(config.hardwareHeaterPumpPin, GPIO.OUT)
         GPIO.setup(config.hardwareHeaterPin, GPIO.OUT)
         GPIO.setup(config.hardwareCoolearPin, GPIO.OUT)
         GPIO.setup(config.hardwareStirrerPin, GPIO.OUT)
 
+        GPIO.output(config.hardwareHeaterPumpPin, RELAY_OFF)
         GPIO.output(config.hardwareHeaterPin, RELAY_OFF)
         GPIO.output(config.hardwareCoolearPin, RELAY_OFF)
         GPIO.output(config.hardwareStirrerPin, RELAY_OFF)
@@ -107,6 +109,7 @@ def turnHeaterOn():
     """
     initHardware()
     GPIO.output(config.hardwareHeaterPin, RELAY_ON)
+    GPIO.output(config.hardwareHeaterPumpPin, RELAY_ON)
 
 
 def turnHeaterOff():
@@ -118,6 +121,7 @@ def turnHeaterOff():
     """
     initHardware()
     GPIO.output(config.hardwareHeaterPin, RELAY_OFF)
+    GPIO.output(config.hardwareHeaterPumpPin, RELAY_OFF)
 
 
 def turnCoolerOn():


### PR DESCRIPTION
## TL;DR
Switched the relays on/off values so that the pumps/heater/stirrer don't activate if the pi turns off.

Added a separate control pin for the heater pumps, since the heating element and pumps can run at different voltages we need two relays.

## What
What is affected by this PR?
- [ ] API
- [ ] GUI
- [X] Hardware Integration
- [ ] OS/Deployment
- [ ] Documentation
- [ ] Other (please describe in notes)

## Testing
How was this tested?
- [ ] Locally Virtualized
- [X] Raspberry Pi
- [X] With Hardware
- [ ] Other (please describe in notes)

## Notes
How was your day?