### PR TITLE
Fixed display of estimated recipe time with new recipe format

### DIFF
--- a/gui/src/pages/RecipeDetails.jsx
+++ b/gui/src/pages/RecipeDetails.jsx
@@ -89,7 +89,12 @@ function TimeNeeded({ steps }) {
   const waitTime = reduce(
     steps,
     (sum, step) => {
-      return sum + get(step, 'parameters.time', 0)
+      return sum + reduce(
+        step.tasks, 
+        (max, task) => 
+          Math.max(get(task, 'parameters.time', 0), max),
+        0,
+        )
     },
     0,
   )


### PR DESCRIPTION
## TL;DR
Fixed display of estimated recipe time with new recipe format with multiple tasks per step supported, uses the longest task in the step to estimate with.

## What
What is affected by this PR?
- [ ] API
- [X] GUI
- [ ] Hardware Integration
- [ ] OS/Deployment
- [ ] Documentation
- [ ] Other (please describe in notes)

## Testing
How was this tested?
- [ ] Locally Virtualized
- [X] Raspberry Pi
- [ ] With Hardware
- [ ] Other (please describe in notes)

## Notes
How was your day?