### PR TITLE
Added more simulators for troubleshooting

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -25,7 +25,7 @@ hardwareSpeedup = environ.get("HARDWARE_SPEEDUP", 1)
 
 # Which hardware board the software is being run on, for loading known hardware configuration. 
 # supported values:
-# pi, AML-S905X-CC-V1.0A, custom
+# pi, AML-S905X-CC-V1.0A, hardware_simulation, custom
 # Custom loads nothing. All hardware used must then be specified in base_hardware.yaml 
 hardwareBoard = environ.get("HARDWARE_BOARD", "pi")  
 

--- a/backend/hardware/boardhardwareconfig/hardware_simulation.yaml
+++ b/backend/hardware/boardhardwareconfig/hardware_simulation.yaml
@@ -1,0 +1,102 @@
+# In this file implementation is set as simulation
+devices:
+  - id: "reactor-thermometer"
+    type: "thermometer"
+    # Type of thermometer to use for measuring the temp of the reactor
+    # Supported values: w1_therm, serial, simulation
+    # w1_therm: Supports the DS18S20, DS1822, DS18B20, DS28EA00 and DS1825/MAX31850K
+    #           sensors using the 1 wire protocol. You'll need to add "dtoverlay=w1-gpio"
+    #           to /boot/config.txt and reboot to use this on a pi, see https://github.com/libre-computer-project/libretech-wiring-tool
+    #           for enabling the w1-gpio overlay on the AML-S905X-CC
+    # serial: reads the sensor data from a serial device
+    implementation: "simulation"
+    ## serial MODE CONFIG
+    # Which device to read data from.
+    serialDevice: '/dev/ttyUSB0'
+
+  - id: "reactor-temperature-controller"
+    type: "tempController"
+    # Which temperature controller implementation to use
+    # Supported values: basic, simulation
+    # basic: Basic hardware setup using two sets of pumps and a heating element
+    #        some currently incomplete instructions for this are in docs/assembly
+    # simulation: Simulates temperature changes due to heater and cooler activation
+    #             No other configuration required or possible at the moment
+    implementation: "simulation"
+    # device ID of the thermometer to use for detecting reactor temperature
+    thermometerID: "reactor-thermometer"
+    gpioID: "gpio-primary"
+    # GPIO pin for activating the heating element
+    heaterPin: BCM_26
+    # GPIO pin for activating the heater pump(s)
+    heaterPumpPin: BCM_20
+    # GPIO pin for activating the cooler pump(s)
+    coolerPin: BCM_21
+    # list of device IDs that must be setup before this device
+    dependencies: ["reactor-thermometer"]
+
+  - id: "reactor-reagent-dispenser"
+    type: "reagentDispenser"
+    # Which reagent dispenser implementation to use
+    # Supported values: syringepump, simulation, peristalticpump
+    # syringepump: The open source syringe pump referenced in the assembly documentation
+    #              Uses grbl and stepper motors to dispense the reagents into the microlab
+    # simulation: Does nothing but sleep to simulate dispensing a reagent
+    implementation: "simulation"
+    ## syringepump MODE CONFIG
+    # Serial device for communication with the Arduino
+    arduinoPort: "/dev/ttyACM0"
+    # Configuration for the syringe pump motors
+    syringePumpsConfig:
+      X:
+        # Number of mm the stepper motor moves per full revolution,
+        # this is the pitch of the threaded rod
+        mmPerRev: 0.8
+        # Number of steps per revolution of the stepper motor, reference the documentation for the motor
+        stepsPerRev: 200
+        # Number of mm of movement needed to dispense 1 ml of fluid,
+        # this is the length of the syringe divided by its fluid capacity
+        mmPerml: 3.5
+        # Maximum speed the motor should run in mm/min
+        maxmmPerMin: 240
+      Y:
+        # These are all the same as documented above but for the Y axis
+        mmPerRev: 0.8
+        stepsPerRev: 200
+        mmPerml: 3.5
+        maxmmPerMin: 240
+      Z:
+        # These are all the same as documented above but for the Y axis
+        mmPerRev: 0.8
+        stepsPerRev: 200
+        mmPerml: 3.5
+        maxmmPerMin: 240
+    # Configuration for the peristaltic pump motors
+    peristalticPumpsConfig:
+      F: 175
+      X:
+        # scaling factor based on initial calibration
+        mlPerUnit: 0.5555555
+      Y:
+        # scaling factor based on initial calibration
+        mlPerUnit: 0.5555555
+      Z:
+        # scaling factor based on initial calibration
+        mlPerUnit: 0.5555555
+    ## simulation MODE ARGS
+    # None needed or supported at the moment
+
+  - id: "reactor-stirrer"
+    type: "stirrer"
+    # Which stirrer implementation to use
+    # Supported values: gpio_stirrer, simulation
+    # gpio_stirrer: activates the stirrer by switching a gpio pin
+    # simulation: Does nothing
+    implementation: "simulation"
+    gpioID: "gpio-primary"
+    ## gpio_stirrer MODE CONFIG
+    # GPIO pin for activating the stirrer
+    stirrerPin: BCM_16
+
+    ## simulation MODE CONFIG
+    # None needed or supported at the moment

--- a/backend/hardware/gpiochip/__init__.py
+++ b/backend/hardware/gpiochip/__init__.py
@@ -2,10 +2,13 @@
 This module contains the implementations for gpio control. See base.py for the abstract class used
 and the individual files for configuration information.
 """
-from hardware.gpiochip.gpiod import GPIODChip
 
 def createGPIOChip(gpioConfig, devices):
     gpioType = gpioConfig['implementation']
     if gpioType == "gpiod":
+        from hardware.gpiochip.gpiod import GPIODChip
         return GPIODChip(gpioConfig)
+    if gpioType == "simulation":
+        from hardware.gpiochip.gpiod_simulation import GPIODChipSimulation
+        return GPIODChipSimulation(gpioConfig)
     raise Exception("Unsupported gpiochiptype")

--- a/backend/hardware/gpiochip/gpiod_simulation.py
+++ b/backend/hardware/gpiochip/gpiod_simulation.py
@@ -1,0 +1,83 @@
+from hardware.gpiochip.base import GPIOChip, LINE_REQ_DIR_OUT, LINE_REQ_DIR_IN
+
+class GPIODChipSimulation():
+    output_offsets = []
+    output_values = []
+    output_lines = []
+    chip = None
+    lineAliases = {}
+    def __init__(self, args):
+        """
+        Constructor. Initializes the GPIO chip.
+        :param args:
+          dict
+            chipName
+              Name of the chip according to gpiod
+            lineAliases
+              dictionary mapping strings to line numbers
+              for adding human readable names to GPIO lines
+        """
+        print(self.lineAliases)
+
+
+    def __output(self):
+        """
+        Outputs values on every line that has been setup
+        """
+
+    def __getLineNumber(self, pin):
+        """
+        Converts string aliases to the corresponding line number
+        Throws an exception if pin is an alias that does not exist.
+        :param pin:
+            The pin to get the line number of.
+        :return:
+            The line number for that pin
+        """
+        if type(pin) == str:
+          if self.lineAliases[pin]:
+            return self.lineAliases[pin]
+          else:
+            raise Exception("Invalid GPIO pin {0}".format(pin))
+        else:
+          return pin
+
+    def setup(self, pin, pinType=LINE_REQ_DIR_OUT, outputValue=0):
+        """
+        Sets up pin for use, currently only output is supported.
+
+        :param pin:
+            The pin to setup. Either a defined alias or the line number for the pin
+        :param pinType:
+            One of "output" or "input". Currently only "output is supported"
+        :param outputValue:
+            Either 0 or 1, the value to output on the pin
+        :return:
+            None
+        """
+        lineNumber = self.__getLineNumber(pin)
+        
+        # add better simulation
+
+        if pinType == LINE_REQ_DIR_OUT:
+          self.output_offsets.append(lineNumber)
+          self.output_values.append(outputValue)
+          self.__output()
+        
+
+    def output(self, pin, value):
+        """
+        Outputs a new value to specified pin
+
+        :param pin:
+            The pin to output on. Either a defined alias or the line number for the pin
+        :param outputValue:
+            Either 0 or 1, the value to output on the pin
+        :return:
+            None
+        """
+        lineNumber = self.__getLineNumber(pin)
+        index = self.output_offsets.index(lineNumber)
+        self.output_values[index] = value
+        self.__output()
+

--- a/backend/hardware/thermometer/__init__.py
+++ b/backend/hardware/thermometer/__init__.py
@@ -2,14 +2,15 @@
 This module contains the implementations of the thermometer. See base.py for the abstract class used
 and either the individual files or backend/config.py for configuration information.
 """
-from hardware.thermometer.w1_therm import W1TempSensor
-from hardware.thermometer.serial import SerialTempSensor
-
 def createThermometer(thermometerConfig, devices):
   thermometerType = thermometerConfig['implementation']
   if thermometerType == "w1_therm":
+    from hardware.thermometer.w1_therm import W1TempSensor
     return W1TempSensor()
   elif thermometerType == "serial":
+    from hardware.thermometer.serial import SerialTempSensor
     return SerialTempSensor(thermometerConfig) 
-  
+  elif thermometerType == "simulation":
+    from hardware.thermometer.serial_simulation import SerialTempSensorSimulation
+    return SerialTempSensorSimulation(thermometerConfig) 
   raise Exception("Unsupported thermometer type")

--- a/backend/hardware/thermometer/serial_simulation.py
+++ b/backend/hardware/thermometer/serial_simulation.py
@@ -1,0 +1,31 @@
+from hardware.thermometer.base import TempSensor
+import time
+
+class SerialTempSensorSimulation(TempSensor):
+    tempSer = None
+    def __init__(self, args):
+        """
+        Constructor. Initializes the sensor.
+        :param args:
+          dict
+            serialDevice
+              A string with the device read from
+        """
+        self.tempSer = 0
+
+    def getTemp(self):
+        """
+        Get the temperature of the sensor in celsius.
+        Recommended sensor: DS18B20
+
+        A successful read looks something like this: b"t1=+29.06\n"
+        The loop below looks for the '=' '\n' '.' to detect success
+
+        :return:
+            Temperature in Celsius
+        """
+        line = "12345678901"
+        lastLine = "+29.06"
+        temperature = float(lastLine[start:end])
+        return temperature
+       


### PR DESCRIPTION
When using docker compose method on Windows 10 not all containers started successfully
This is due to error in load_kernel_modules unable to load temp and gpio

I left config.py file unchanged but added 
hardwareBoard = environ.get("HARDWARE_BOARD", "simulation")  
to keep it easy to configure

Added missing simulation stubs, so it is possible to explore code 

## What
What is affected by this PR?
- [ ] API
- [ ] GUI
- [x] Hardware Integration
- [ ] OS/Deployment
- [ ] Documentation
- [ ] Other (please describe in notes)

## Testing
How was this tested?
- [ ] Locally Virtualized
- [ ] Raspberry Pi
- [ ] With Hardware
- [x] Other (please describe in notes)

To tun this project locally without hardware it was impossible to run
The problem was in failed docker API container that relays on hardware libraries w1_therm sensor inside load_kernel_modules function.
Also not all required hardware contained a simulations to let it run, debug and easy investigate code
## Notes
error stack:
2024-01-01 20:00:40 Traceback (most recent call last):
2024-01-01 20:00:40   File "main.py", line 5, in <module>
2024-01-01 20:00:40     from api import app
2024-01-01 20:00:40   File "/app/api/__init__.py", line 14, in <module>
2024-01-01 20:00:40     from api import routes
2024-01-01 20:00:40   File "/app/api/routes.py", line 9, in <module>
2024-01-01 20:00:40     import recipes
2024-01-01 20:00:40   File "/app/recipes/__init__.py", line 17, in <module>
2024-01-01 20:00:40     from recipes.base import Recipe
2024-01-01 20:00:40   File "/app/recipes/base.py", line 85, in <module>
2024-01-01 20:00:40     from recipes import celery
2024-01-01 20:00:40   File "/app/recipes/celery.py", line 16, in <module>
2024-01-01 20:00:40     from recipes import state, tasks
2024-01-01 20:00:40   File "/app/recipes/tasks.py", line 2, in <module>
2024-01-01 20:00:40     from hardware import microlab
2024-01-01 20:00:40   File "/app/hardware/__init__.py", line 15, in <module>
2024-01-01 20:00:40     import hardware.temperaturecontroller as tc
2024-01-01 20:00:40   File "/app/hardware/temperaturecontroller/__init__.py", line 7, in <module>
2024-01-01 20:00:40     from hardware.temperaturecontroller.basictempcontroller import BasicTempController
2024-01-01 20:00:40   File "/app/hardware/temperaturecontroller/basictempcontroller.py", line 2, in <module>
2024-01-01 20:00:40     import hardware.thermometer as therm
2024-01-01 20:00:40   File "/app/hardware/thermometer/__init__.py", line 5, in <module>
2024-01-01 20:00:40     from hardware.thermometer.w1_therm import W1TempSensor
2024-01-01 20:00:40   File "/app/hardware/thermometer/w1_therm.py", line 2, in <module>
2024-01-01 20:00:40     from w1thermsensor import W1ThermSensor, Sensor, SensorNotReadyError
2024-01-01 20:00:40   File "/usr/local/lib/python3.8/site-packages/w1thermsensor/__init__.py", line 38, in <module>
2024-01-01 20:00:40     load_kernel_modules()
2024-01-01 20:00:40   File "/usr/local/lib/python3.8/site-packages/w1thermsensor/kernel.py", line 40, in load_kernel_modules
2024-01-01 20:00:40     raise KernelModuleLoadError()
2024-01-01 20:00:40 w1thermsensor.errors.KernelModuleLoadError: Cannot load w1 therm kernel modules