### PR TITLE
Standardize api status codes and methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@
 - Configuration is now stored in /etc/microlab instead of backend/config.py (#141).
 - Recipe data was moved from /backend/recipes/files to being stored by default at /var/lib/microlab/recipes. Recipes in the repository are kept at backend/data/recipes and copied to their proper storage location at launch. (#141).
 - Hardware configuration files were moved from backend/hardware to being stored by default at /var/lib/microlab/controllerhardware and /var/lib/microlab/labhardware. Hardware configurations in the repository are kept at backend/data/hardware and copied to their proper storage location at launch. (#141).
+- The API endpoints `/start/<name>`, `/stop`, `/select/option/<name>`, `/controllerHardware/<name>`, `/labHardware/<name>` are now POST rather than GET. (#144).
 
 ### Fixed
 
 - Bug when multiple gpiod instances were being used (#141).
 - Syringe pump configuration was not being used (#118).
+- Error responses no longer return status code 200. (#144).
 
 ### Removed
 

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -103,11 +103,17 @@ def start(name):
         message
             Only present if response is "error" and there is a message to present to the user.
     """
+    recipe = recipes.getRecipeByName(name)
+    if recipe == None:
+        return jsonify({'response': 'error', 
+                        'message': 'Recipe with this name could not be found'}
+                        ), 404
+                        
     (state, msg) = microlabInterface.start(name)
     if state:
         return jsonify({'response': 'ok'})
     else:
-        return jsonify({'response': 'error', 'message': msg})
+        return jsonify({'response': 'error', 'message': msg}), 500
 
 
 @app.route('/stop')
@@ -150,7 +156,7 @@ def selectOption(name):
     if state:
         return jsonify({'response': 'ok'})
     else:
-        return jsonify({'response': 'error', 'message': msg})
+        return jsonify({'response': 'error', 'message': msg}), 400
 
 @app.route('/uploadRecipe', methods = ['POST'])
 def uploadRecipe():

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -87,7 +87,7 @@ def status():
     return jsonify(microlabInterface.status())
 
 
-@app.route('/start/<name>')
+@app.route('/start/<name>', methods=['POST'])
 def start(name):
     """
     Start running a recipe.
@@ -116,7 +116,7 @@ def start(name):
         return jsonify({'response': 'error', 'message': msg}), 500
 
 
-@app.route('/stop')
+@app.route('/stop', methods=['POST'])
 def stop():
     """
     Stop the currently running recipe.
@@ -134,7 +134,7 @@ def stop():
     return jsonify({'response': 'ok'})
 
 
-@app.route('/select/option/<name>')
+@app.route('/select/option/<name>', methods=['POST'])
 def selectOption(name):
     """
     Provide user selected input.
@@ -211,7 +211,7 @@ def listControllerHardware():
     configs = list(map(lambda x: x[:-5], filter(lambda x: x.endswith(".yaml"), files)))
     return jsonify(configs)
 
-@app.route('/controllerHardware/<name>')
+@app.route('/controllerHardware/<name>', methods=['POST'])
 def selectControllerHardware(name):
     """
     Sets a new controller hardware setting, and reloads the hardware
@@ -291,7 +291,7 @@ def listLabHardware():
     configs = list(map(lambda x: x[:-5], filter(lambda x: x.endswith(".yaml"), files)))
     return jsonify(configs)
 
-@app.route('/labHardware/<name>')
+@app.route('/labHardware/<name>', methods=['POST'])
 def selectLabHardware(name):
     """
     Sets a new lab hardware setting, and reloads the hardware

--- a/gui/src/pages/RecipeDetails.jsx
+++ b/gui/src/pages/RecipeDetails.jsx
@@ -19,7 +19,9 @@ export function RecipeDetails() {
   }, [recipeName])
 
   const startRecipe = name => {
-    fetch(apiUrl + 'start/' + name)
+    fetch(apiUrl + 'start/' + name, {
+      method: 'POST',
+    })
       .then(response => response.json())
       .then(data => history.push('/status'))
   }

--- a/gui/src/utils.js
+++ b/gui/src/utils.js
@@ -23,19 +23,25 @@ export const listRecipes = callback => {
 }
 
 export const selectOption = option => {
-  fetch(apiUrl + 'select/option/' + option)
+  fetch(apiUrl + 'select/option/' + option, {
+    method: 'POST',
+  })
     .then(response => response.json())
     .then(data => console.log(data))
 }
 
 export const stopRecipe = () => {
-  fetch(apiUrl + 'stop')
+  fetch(apiUrl + 'stop', {
+    method: 'POST',
+  })
     .then(response => response.json())
     .then(data => console.log(data))
 }
 
 export const startRecipe = name => {
-  fetch(apiUrl + 'start/' + name)
+  fetch(apiUrl + 'start/' + name, {
+    method: 'POST',
+  })
     .then(response => response.json())
     .then(data => console.log(data))
 }
@@ -60,7 +66,9 @@ export const listControllerHardware = () => {
 }
 
 export const setControllerHardware = name => {
-  return fetch(apiUrl + 'controllerHardware/' + name).then(response => response.json())
+  return fetch(apiUrl + 'controllerHardware/' + name, {
+    method: 'POST',
+  }).then(response => response.json())
 }
 
 export const downloadControllerConfig = name => {
@@ -88,7 +96,9 @@ export const listLabHardware = () => {
 }
 
 export const setLabHardware = name => {
-  return fetch(apiUrl + 'labHardware/' + name).then(response => response.json())
+  return fetch(apiUrl + 'labHardware/' + name, {
+    method: 'POST',
+  }).then(response => response.json())
 }
 
 export const uploadLabConfig = file => {


### PR DESCRIPTION
## TL;DR
Quick summary/list of your change(s)
Errors no longer return status code 200.
Endpoints that perform mutations are now POST requests rather than GET requests

## What
What is affected by this PR?
- [X] API
- [ ] GUI
- [ ] Hardware Integration
- [ ] OS/Deployment
- [ ] Documentation
- [ ] Other (please describe in notes)

## Testing
How was this tested?
- [ ] Locally Virtualized
- [ ] Raspberry Pi
- [X] With Hardware
- [ ] Other (please describe in notes)

## Notes
How was your day?