### PR TITLE
Clear the brower's exited_cleanly flag on startup, set it to 'true'

### DIFF
--- a/scripts/startBrowser.sh
+++ b/scripts/startBrowser.sh
@@ -1,4 +1,9 @@
 # Start a Browser going to localhost:3000
 # xdg-open http://localhost:3000
 
+# Reset the "exited_cleanly" flag for chromium
+sed -i 's/"exited_cleanly": false/"exited_cleanly": true/' \
+    ~/.config/google-chrome/Default/Preferences
+
+#Launch a Chrome browser in kiosk mode
 /usr/lib/chromium-browser/chromium-browser-v7 --force-renderer-accessibility --enable-remote-extensions --enable-pinch --enable-crashpad --start-fullscreen --hide-crash-restore-bubble --kiosk --app=http://localhost:3000


### PR DESCRIPTION
## TL;DR
When the browser starts, set the "exited_cleanly" flag to "true". Relates to [issue 133](https://github.com/FourThievesVinegar/solderless-microlab/issues/133)

## What
What is affected by this PR?
- [ ] API
- [x] GUI
- [ ] Hardware Integration
- [ ] OS/Deployment
- [ ] Documentation
- [ ] Other (please describe in notes)

## Testing
How was this tested?
- [x] Locally Virtualized
- [ ] Raspberry Pi
- [ ] With Hardware
- [ ] Other (please describe in notes)

## Notes
How was your day?
Not bad - a little tired.