### PR TITLE
Add shebang to startBrowser.sh script

### DIFF
--- a/scripts/startBrowser.sh
+++ b/scripts/startBrowser.sh
@@ -1,3 +1,5 @@
+
+#!/bin/bash
 # Start a Browser going to localhost:3000
 # xdg-open http://localhost:3000
 


### PR DESCRIPTION
## TL;DR
The startBrowser.sh script needed a shebang (#!/bin/bash) at the beginning

## What
What is affected by this PR?
- [ ] API
- [ ] GUI
- [ ] Hardware Integration
- [x] OS/Deployment
- [ ] Documentation
- [ ] Other (please describe in notes)

## Testing
How was this tested?
- [ ] Locally Virtualized
- [ ] Raspberry Pi
- [ ] With Hardware
- [ ] Other (please describe in notes)

## Notes
How was your day?