### PR TITLE
back off on status requests a little. Give the API a break.

### DIFF
--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -26,7 +26,7 @@ export function App() {
   useEffect(() => {
     const interval = setInterval(() => {
       getStatus(setStatus)
-    }, 1000)
+    }, 2500)
     return () => clearInterval(interval)
   }, [])
 


### PR DESCRIPTION
## TL;DR
This makes the GUI only hit the status endpoint every 2.5 seconds instead of every second. What's the rush? Not much is happening second-to-second.

## What
What is affected by this PR?
- [ ] API
- [x] GUI
- [ ] Hardware Integration
- [ ] OS/Deployment
- [ ] Documentation
- [ ] Other (please describe in notes)

## Testing
How was this tested?
- [ ] Locally Virtualized
- [ ] Raspberry Pi
- [ ] With Hardware
- [ ] Other (please describe in notes)

## Notes
How was your day?