### PR TITLE
Load hardware config type hints

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -5,6 +5,7 @@ disk and/or passed in as environment variables. Import and use this file with
 Configuration is stored on disk at '/etc/microlab/microlab.ini'
 """
 import os
+import logging
 from os import environ, makedirs, path
 from configobj import ConfigObj, flatten_errors
 from configobj.validate import Validator 
@@ -62,10 +63,6 @@ class MicrolabConfig:
     @property
     def recipesDirectory(self):
         return '{0}/recipes/'.format(self.dataDirectory)
-
-    @property
-    def controllerHardwareDirectory(self):
-        return '{0}/controllerhardware/'.format(self.hardwareDirectory)
 
     @property
     def logDirectory(self):

--- a/backend/hardware/__init__.py
+++ b/backend/hardware/__init__.py
@@ -23,7 +23,7 @@ class MicroLabHardwareState(Enum):
     FAILED_TO_START = "FAILED_TO_START"
 
 class MicroLabHardware:
-    def __init__(self, deviceDefinition):
+    def __init__(self, deviceDefinition: list[dict]):
         """
         Constructor. Initializes the hardware.
         """
@@ -35,7 +35,7 @@ class MicroLabHardware:
         self.startTime = time.monotonic()
         self.loadHardware(deviceDefinition)
 
-    def loadHardware(self, deviceDefinition):
+    def loadHardware(self, deviceDefinition: list[dict]):
         """
         Loads and initializes the hardware devices
 

--- a/backend/hardware/devicelist.py
+++ b/backend/hardware/devicelist.py
@@ -9,7 +9,7 @@ from os.path import exists
 import logging
 
 
-def loadHardwareConfiguration():
+def loadHardwareConfiguration() -> dict:
     if config.controllerHardware != "custom":
         path = '{0}/{1}.yaml'.format(config.controllerHardwareDirectory, config.controllerHardware)
         if not exists(path):
@@ -24,12 +24,10 @@ def loadHardwareConfiguration():
     return {"devices": controllerHardware["devices"] + userHardware["devices"]}
 
 
-def setupDevices(deviceDefinitions):
+def setupDevices(deviceDefinitions: list[dict]):
     validateConfiguration(deviceDefinitions)
     
-    devices = {
-
-    }
+    devices = {}
 
     for device in deviceDefinitions:
         logging.info('Loading device "{0}".'.format(device['id']))
@@ -52,11 +50,11 @@ def setupDevices(deviceDefinitions):
     return devices
 
 
-def validateConfiguration(deviceConfigs):
+def validateConfiguration(deviceConfigs: list[dict]):
     deviceDict = {}
     for device in deviceConfigs:
 
-        if deviceDict.get(device['id'], None) == None:
+        if deviceDict.get(device['id'], None) is None:
             deviceDict[device['id']] = device
         else:
             raise Exception("Duplicate device id {0}".format(device['id']))

--- a/backend/hardware/gpiochip/__init__.py
+++ b/backend/hardware/gpiochip/__init__.py
@@ -3,7 +3,8 @@ This module contains the implementations for gpio control. See base.py for the a
 and the individual files for configuration information.
 """
 
-def createGPIOChip(gpioConfig, devices):
+
+def createGPIOChip(gpioConfig: dict, devices: dict):
     gpioType = gpioConfig['implementation']
     if gpioType == "gpiod":
         from hardware.gpiochip.gpiod import GPIODChip

--- a/backend/hardware/gpiochip/gpiod.py
+++ b/backend/hardware/gpiochip/gpiod.py
@@ -1,13 +1,13 @@
-from hardware.gpiochip.base import GPIOChip, LINE_REQ_DIR_OUT, LINE_REQ_DIR_IN
+from hardware.gpiochip.base import GPIOChip, LINE_REQ_DIR_OUT
 import gpiod
 import logging
 
 
 class GPIODChip(GPIOChip):
-    def __init__(self, args):
+    def __init__(self, gpio_config: dict):
         """
         Constructor. Initializes the GPIO chip.
-        :param args:
+        :param gpio_config:
           dict
             chipName
               Name of the chip according to gpiod
@@ -20,9 +20,9 @@ class GPIODChip(GPIOChip):
         self.output_lines = []
         self.chip = None
         self.lineAliases = {}
-        self.chip = gpiod.Chip(args['chipName'])
-        if 'lineAliases' in args:
-            for alias, line in args['lineAliases'].items():
+        self.chip = gpiod.Chip(gpio_config['chipName'])
+        if 'lineAliases' in gpio_config:
+            for alias, line in gpio_config['lineAliases'].items():
                 self.lineAliases[alias] = line
         logging.debug(self.lineAliases)
 
@@ -44,7 +44,7 @@ class GPIODChip(GPIOChip):
         :return:
             The line number for that pin
         """
-        if type(pin) == str:
+        if isinstance(pin, str):
             if self.lineAliases[pin]:
                 return self.lineAliases[pin]
             else:

--- a/backend/hardware/gpiochip/gpiod_chipset.py
+++ b/backend/hardware/gpiochip/gpiod_chipset.py
@@ -1,13 +1,12 @@
-from hardware.gpiochip.base import GPIOChip, LINE_REQ_DIR_OUT, LINE_REQ_DIR_IN
-import gpiod
+from hardware.gpiochip.base import GPIOChip, LINE_REQ_DIR_OUT
 import logging
 
 
 class GPIODChipset(GPIOChip):
-    def __init__(self, args, devices):
+    def __init__(self, gpio_config: dict, devices: dict):
         """
         Constructor. Initializes the GPIO chip.
-        :param args:
+        :param gpio_config:
           dict
             chipName
               Name of the chip according to gpiod
@@ -16,9 +15,9 @@ class GPIODChipset(GPIOChip):
               for adding human readable names to GPIO lines
         """
         self.chips = {
-            "defaultChip": devices[args["defaultChipID"]],
+            "defaultChip": devices[gpio_config["defaultChipID"]],
         }
-        for chipID in args['additionalChips']:
+        for chipID in gpio_config['additionalChips']:
             self.chips[chipID] = devices[chipID]
         
         self.lineAliases = {}

--- a/backend/hardware/gpiochip/gpiod_simulation.py
+++ b/backend/hardware/gpiochip/gpiod_simulation.py
@@ -1,12 +1,12 @@
-from hardware.gpiochip.base import GPIOChip, LINE_REQ_DIR_OUT, LINE_REQ_DIR_IN
+from hardware.gpiochip.base import LINE_REQ_DIR_OUT
 import logging
 
 
 class GPIODChipSimulation():
-    def __init__(self, args):
+    def __init__(self, gpio_config: dict):
         """
         Constructor. Initializes the GPIO chip.
-        :param args:
+        :param gpio_config:
           dict
             chipName
               Name of the chip according to gpiod
@@ -19,8 +19,8 @@ class GPIODChipSimulation():
         self.output_lines = []
         self.chip = None
         self.lineAliases = {}
-        if 'lineAliases' in args:
-            for alias, line in args['lineAliases'].items():
+        if 'lineAliases' in gpio_config:
+            for alias, line in gpio_config['lineAliases'].items():
                 self.lineAliases[alias] = line
         logging.debug(self.lineAliases)
 
@@ -38,7 +38,7 @@ class GPIODChipSimulation():
         :return:
             The line number for that pin
         """
-        if type(pin) == str:
+        if isinstance(pin, str):
             if self.lineAliases[pin]:
                 return self.lineAliases[pin]
             else:

--- a/backend/hardware/reagentdispenser/__init__.py
+++ b/backend/hardware/reagentdispenser/__init__.py
@@ -6,7 +6,8 @@ from hardware.reagentdispenser.peristalticpump import PeristalticPump
 from hardware.reagentdispenser.syringepump import SyringePump
 from hardware.reagentdispenser.simulation import SimulatedReagentDispenser
 
-def createReagentDispenser(reagentdispenserConfig, devices):
+
+def createReagentDispenser(reagentdispenserConfig: dict, devices: dict):
     reagentdispenserType = reagentdispenserConfig['implementation']
     if reagentdispenserType == "syringepump":
         return SyringePump(reagentdispenserConfig)

--- a/backend/hardware/reagentdispenser/base.py
+++ b/backend/hardware/reagentdispenser/base.py
@@ -33,3 +33,31 @@ class ReagentDispenser(ABC):
                     Maximum speed the pump can dispense in ml/s
         """
         pass
+
+    @classmethod
+    def grblWrite(cls, grblSer, command, retries=3):
+        """
+        Writes the given command to grbl.
+
+        :param grblSer:
+        Serial device to write the command to
+
+        :param command:
+        String of grbl command to execute
+
+        :return:
+        None
+        """
+        grblSer.reset_input_buffer()
+        grblSer.write(bytes(command, "utf-8"))
+        # Grbl will execute commands in serial as soon as the previous is completed.
+        # No need to wait until previous commands are complete. Ok only signifies that it
+        # parsed the command
+        response = grblSer.read_until()
+        if "error" in str(response):
+            if retries > 0:
+                cls.grblWrite(grblSer, command, retries - 1)
+            else:
+                raise Exception(
+                    "grbl error: {0} for command: {1}".format(response, command)
+                )

--- a/backend/hardware/reagentdispenser/simulation.py
+++ b/backend/hardware/reagentdispenser/simulation.py
@@ -1,6 +1,6 @@
-from hardware.reagentdispenser.base import ReagentDispenser
-import time
 import logging
+
+from hardware.reagentdispenser.base import ReagentDispenser
 
 
 def log(message):
@@ -8,13 +8,13 @@ def log(message):
 
 
 class SimulatedReagentDispenser(ReagentDispenser):
-    def __init__(self, args):
+    def __init__(self, reagent_dispenser_config: dict):
         self.minSpeed = 0.1
         self.maxSpeed = 10
-        if 'minSpeed' in args:
-            self.minSpeed = args['minSpeed'] 
-        if 'maxSpeed' in args:
-            self.maxSpeed = args['maxSpeed'] 
+        if 'minSpeed' in reagent_dispenser_config:
+            self.minSpeed = reagent_dispenser_config['minSpeed']
+        if 'maxSpeed' in reagent_dispenser_config:
+            self.maxSpeed = reagent_dispenser_config['maxSpeed']
 
     def dispense(self, pumpId, volume, duration=None):
         """

--- a/backend/hardware/reagentdispenser/syringepump.py
+++ b/backend/hardware/reagentdispenser/syringepump.py
@@ -1,44 +1,14 @@
-import time
-import config
 import serial
 from hardware.reagentdispenser.base import ReagentDispenser
 import logging
 import math
 
 
-def grblWrite(grblSer, command, retries=3):
-    """
-    Writes the given command to grbl.
-
-    :param grblSer:
-    Serial device to write the command to
-
-    :param command:
-    String of grbl command to execute
-
-    :return:
-    None
-    """
-    grblSer.reset_input_buffer()
-    grblSer.write(bytes(command, "utf-8"))
-    # Grbl will execute commands in serial as soon as the previous is completed.
-    # No need to wait until previous commands are complete. Ok only signifies that it
-    # parsed the command
-    response = grblSer.read_until()
-    if "error" in str(response):
-        if retries > 0:
-            grblWrite(grblSer, command, retries - 1)
-        else:
-            raise Exception(
-                "grbl error: {0} for command: {1}".format(response, command)
-            )
-
-
 class SyringePump(ReagentDispenser):
-    def __init__(self, args):
+    def __init__(self, reagent_dispenser_config: dict):
         """
         Constructor. Initializes the pumps.
-        :param args:
+        :param reagent_dispenser_config:
           dict
             arduinoPort
                 string - Serial device for communication with the Arduino
@@ -76,8 +46,8 @@ class SyringePump(ReagentDispenser):
                     mmPerml
                     maxmmPerMin
         """
-        self.syringePumpsConfig = args["syringePumpsConfig"]
-        self.grblSer = serial.Serial(args["arduinoPort"], 115200, timeout=1)
+        self.syringePumpsConfig = reagent_dispenser_config["syringePumpsConfig"]
+        self.grblSer = serial.Serial(reagent_dispenser_config["arduinoPort"], 115200, timeout=1)
         self.axisMinmmPerMin = {}
         for axis, syringeConfig in self.syringePumpsConfig.items():
             stepsPerMM = syringeConfig["stepsPerRev"] / syringeConfig["mmPerRev"]
@@ -88,11 +58,11 @@ class SyringePump(ReagentDispenser):
             }
             self.axisMinmmPerMin[axis] = math.ceil((30 / stepsPerMM) * 120)
             # configure steps/mm
-            grblWrite(
+            self.grblWrite(
                 self.grblSer, "$10{0}={1}\n".format(axisToCNCID[axis], stepsPerMM)
             )
             # configure max mm/min
-            grblWrite(
+            self.grblWrite(
                 self.grblSer,
                 "$11{0}={1}\n".format(axisToCNCID[axis], syringeConfig["maxmmPerMin"]),
             )
@@ -117,7 +87,7 @@ class SyringePump(ReagentDispenser):
         totalmm = volume * mmPerml
         command = "G91 G1 {0}{1} F{2}\n".format(pumpId, totalmm, dispenseSpeed)
         logging.debug("Dispensing with command '{}'".format(command))
-        grblWrite(self.grblSer, command)
+        self.grblWrite(self.grblSer, command)
         dispenseTime = abs(totalmm) / (dispenseSpeed / 60)
 
         logging.info(

--- a/backend/hardware/stirring/__init__.py
+++ b/backend/hardware/stirring/__init__.py
@@ -6,7 +6,8 @@ and either the individual files or backend/config.py for configuration informati
 from hardware.stirring.gpiostirrer import GPIOStirrer
 from hardware.stirring.simulation import SimulatedStirrer
 
-def createStirrer(stirrerConfig, devices):
+
+def createStirrer(stirrerConfig: dict, devices: dict):
     stirrerType = stirrerConfig['implementation']
     if stirrerType == "gpio_stirrer":
         return GPIOStirrer(stirrerConfig, devices)

--- a/backend/hardware/stirring/gpiostirrer.py
+++ b/backend/hardware/stirring/gpiostirrer.py
@@ -6,18 +6,18 @@ RELAY_OFF = 0
 
 class GPIOStirrer(Stirrer):
 
-    def __init__(self, args, devices):
+    def __init__(self, stirrer_config: dict, devices: dict):
         """
         Constructor. Initializes the stirrer.
-        :param args:
+        :param stirrer_config:
           dict
             stirrerPin
               Which gpio pin to control the stirrer
             gpioID
               The ID of the GPIO device used to control stirring
         """
-        self.gpio = devices[args["gpioID"]]
-        self.stirrerPin = args["stirrerPin"]
+        self.gpio = devices[stirrer_config["gpioID"]]
+        self.stirrerPin = stirrer_config["stirrerPin"]
         
         self.gpio.setup(self.stirrerPin)
         self.gpio.output(self.stirrerPin, RELAY_OFF)

--- a/backend/hardware/temperaturecontroller/__init__.py
+++ b/backend/hardware/temperaturecontroller/__init__.py
@@ -3,11 +3,11 @@ This module contains the implementations of the temperature controller. See base
 and either the individual files or backend/config.py for configuration information.
 """
 
-import config
 from hardware.temperaturecontroller.basictempcontroller import BasicTempController
 from hardware.temperaturecontroller.simulation import SimulatedTempController
 
-def createTemperatureController(tempControllerConfig, devices):
+
+def createTemperatureController(tempControllerConfig: dict, devices: dict):
     tempControllerType = tempControllerConfig['implementation']
     if tempControllerType == "basic":
         return BasicTempController(tempControllerConfig, devices)

--- a/backend/hardware/temperaturecontroller/basictempcontroller.py
+++ b/backend/hardware/temperaturecontroller/basictempcontroller.py
@@ -7,10 +7,10 @@ RELAY_OFF = 0
 
 
 class BasicTempController(TempController):
-    def __init__(self, args, devices):
+    def __init__(self, temp_controller_config: dict, devices: dict):
         """
         Constructor. Initializes the stirrer.
-        :param args:
+        :param temp_controller_config:
           dict
             heaterPin
               Which gpio pin to control the heating element
@@ -25,13 +25,13 @@ class BasicTempController(TempController):
             minTemp
               Minimum temperature the hardware will support
         """
-        super().__init__(args, devices)
-        self.gpio = devices[args["gpioID"]]
-        self.heaterPin = args["heaterPin"]
-        self.heaterPumpPin = args["heaterPumpPin"]
-        self.coolerPin = args["coolerPin"]
-        self.maxTemp = args["maxTemp"]
-        self.minTemp = args["minTemp"]
+        super().__init__(temp_controller_config, devices)
+        self.gpio = devices[temp_controller_config["gpioID"]]
+        self.heaterPin = temp_controller_config["heaterPin"]
+        self.heaterPumpPin = temp_controller_config["heaterPumpPin"]
+        self.coolerPin = temp_controller_config["coolerPin"]
+        self.maxTemp = temp_controller_config["maxTemp"]
+        self.minTemp = temp_controller_config["minTemp"]
 
         self.gpio.setup(self.heaterPin)
         self.gpio.setup(self.heaterPumpPin)
@@ -41,7 +41,7 @@ class BasicTempController(TempController):
         self.gpio.output(self.heaterPumpPin, RELAY_OFF)
         self.gpio.output(self.coolerPin, RELAY_OFF)
 
-        self.thermometer = devices[args["thermometerID"]]
+        self.thermometer = devices[temp_controller_config["thermometerID"]]
 
     def turnHeaterOn(self):
         """

--- a/backend/hardware/temperaturecontroller/simulation.py
+++ b/backend/hardware/temperaturecontroller/simulation.py
@@ -1,4 +1,3 @@
-import time
 from hardware.temperaturecontroller.base import TempController
 import logging
 
@@ -8,15 +7,15 @@ def log(message):
 
 
 class SimulatedTempController(TempController):
-    def __init__(self, args):
-        super().__init__(args, devices=None)
-        self.maxTemp = args["maxTemp"]
-        self.minTemp = args["minTemp"]
+    def __init__(self, sim_temp_controller_config: dict):
+        super().__init__(sim_temp_controller_config, devices=None)
+        self.maxTemp = sim_temp_controller_config["maxTemp"]
+        self.minTemp = sim_temp_controller_config["minTemp"]
         self.heating = False
         self.cooling = False
         self.temperature = 24
-        if 'temp' in args:
-            self.temperature = args['temp'] 
+        if 'temp' in sim_temp_controller_config:
+            self.temperature = sim_temp_controller_config['temp']
 
     def turnHeaterOn(self):
         """
@@ -77,9 +76,9 @@ class SimulatedTempController(TempController):
         if self.temperature == -1:
             self.temperature = 24
         else:
-            if self.heating == True:
+            if self.heating is True:
                 self.temperature = self.temperature + 1
-            elif self.cooling == True:
+            elif self.cooling is True:
                 self.temperature = self.temperature - 1
             else:
                 if self.temperature > 24:

--- a/backend/hardware/thermometer/__init__.py
+++ b/backend/hardware/thermometer/__init__.py
@@ -2,15 +2,17 @@
 This module contains the implementations of the thermometer. See base.py for the abstract class used
 and either the individual files or backend/config.py for configuration information.
 """
-def createThermometer(thermometerConfig, devices):
-  thermometerType = thermometerConfig['implementation']
-  if thermometerType == "w1_therm":
-    from hardware.thermometer.w1_therm import W1TempSensor
-    return W1TempSensor()
-  elif thermometerType == "serial":
-    from hardware.thermometer.serial import SerialTempSensor
-    return SerialTempSensor(thermometerConfig) 
-  elif thermometerType == "simulation":
-    from hardware.thermometer.serial_simulation import SerialTempSensorSimulation
-    return SerialTempSensorSimulation(thermometerConfig) 
-  raise Exception("Unsupported thermometer type")
+
+
+def createThermometer(thermometerConfig: dict, devices: dict):
+    thermometerType = thermometerConfig['implementation']
+    if thermometerType == "w1_therm":
+        from hardware.thermometer.w1_therm import W1TempSensor
+        return W1TempSensor()
+    elif thermometerType == "serial":
+        from hardware.thermometer.serial import SerialTempSensor
+        return SerialTempSensor(thermometerConfig)
+    elif thermometerType == "simulation":
+        from hardware.thermometer.serial_simulation import SerialTempSensorSimulation
+        return SerialTempSensorSimulation(thermometerConfig)
+    raise Exception("Unsupported thermometer type")

--- a/backend/hardware/thermometer/serial.py
+++ b/backend/hardware/thermometer/serial.py
@@ -7,10 +7,10 @@ from datetime import datetime, timedelta
 
 
 class SerialTempSensor(TempSensor):
-    def __init__(self, args):
+    def __init__(self, thermometer_config: dict):
         """
         Constructor. Initializes the sensor.
-        :param args:
+        :param thermometer_config:
           dict
             serialDevice
               A string with the device read from
@@ -19,11 +19,11 @@ class SerialTempSensor(TempSensor):
         self.nextTempReadingTime = datetime.now()
 
         try:
-            self.tempSer = serial.Serial(args["serialDevice"], timeout=0.5)
+            self.tempSer = serial.Serial(thermometer_config["serialDevice"], timeout=0.5)
         except serial.SerialException as e:
             raise HardwareLoadError(
                 "Thermometer could not be detected at {}, make sure it's plugged in, try another USB port if it is, or change the device name in your lab hardware config file to the correct device name.".format(
-                    args["serialDevice"]
+                    thermometer_config["serialDevice"]
                 )
             ) from e
 

--- a/backend/hardware/thermometer/serial_simulation.py
+++ b/backend/hardware/thermometer/serial_simulation.py
@@ -1,19 +1,18 @@
 from hardware.thermometer.base import TempSensor
-import time
 
 
 class SerialTempSensorSimulation(TempSensor):
-    def __init__(self, args):
+    def __init__(self, thermometer_config: dict):
         """
         Constructor. Initializes the sensor.
-        :param args:
+        :param thermometer_config:
           dict
             serialDevice
               A string with the device read from
         """
         self.tempSer = 0
-        if 'temp' in args:
-            self.temp = args['temp']
+        if 'temp' in thermometer_config:
+            self.temp = thermometer_config['temp']
 
     def getTemp(self):
         """
@@ -30,5 +29,10 @@ class SerialTempSensorSimulation(TempSensor):
             return self.temp
         line = "12345678901"
         lastLine = "+29.06"
-        temperature = float(lastLine[start:end])
+
+        # Commenting the below line out for the time being, no 'start' or 'end' variables are defined so this will throw
+        # an exception. Replacing it with just returning a float cast of 'lastLine' as that looks like a valid value
+        # temperature = float(lastLine[start:end])
+
+        temperature = float(lastLine[1:])  # Trimming off the '+' before casting
         return temperature

--- a/backend/hardware/thermometer/w1_therm.py
+++ b/backend/hardware/thermometer/w1_therm.py
@@ -1,5 +1,5 @@
 from hardware.thermometer.base import TempSensor
-from w1thermsensor import W1ThermSensor, Sensor, SensorNotReadyError
+from w1thermsensor import W1ThermSensor, SensorNotReadyError
 from datetime import datetime, timedelta
 
 

--- a/backend/microlab/__init__.py
+++ b/backend/microlab/__init__.py
@@ -3,6 +3,7 @@ Module init.
 Contains function for starting up the microlab process
 """
 
+
 def startMicrolabProcess(in_queue, out_queue):
     """
     Starts up the microlab process
@@ -92,7 +93,6 @@ def startMicrolabProcess(in_queue, out_queue):
 
     microlab = threading.Thread(target=runMicrolab)
     microlab.start()
-
 
     def handleSignal(_a, _b):
         logging.info("")


### PR DESCRIPTION
## TL;DR
Made a number of relatively minor changes along the backend load hardware config path. Highlights include: added type hints, removed unused imports, removed a duplicate property definition, (I believe) fixed the simulated thermometer getTemp value when not set in config, and other smaller changes.

## What
What is affected by this PR?
- [ ] API
- [ ] GUI
- [ ] Hardware Integration
- [ ] OS/Deployment
- [ ] Documentation
- [X] Other (please describe in notes)

## Testing
How was this tested?
- [ ] Locally Virtualized
- [ ] Raspberry Pi
- [ ] With Hardware
- [X] Other (please describe in notes)

## Notes
As before ran unit tests, ran the server and GUI against the running server. I'll add some notes in the PR for the motivation/reasoning behind some of the changes where it might be helpful (apologies if I explain something already known).

Also happy to commit, I love the ethos behind the org's group of projects and am very happy something like this exists at all.