### PR TITLE
Added context manager to file opens in backend to ensure they are closed

### DIFF
--- a/backend/hardware/devicelist.py
+++ b/backend/hardware/devicelist.py
@@ -10,16 +10,19 @@ import logging
 
 
 def loadHardwareConfiguration() -> dict:
+    controllerHardware = {"devices": []}
+
     if config.controllerHardware != "custom":
         path = '{0}/{1}.yaml'.format(config.controllerHardwareDirectory, config.controllerHardware)
         if not exists(path):
             raise Exception("No board configuration found for '{0}'".format(config.controllerHardware))
-        controllerHardware = yaml.safe_load(open(path, 'r'))
-    else:
-        controllerHardware = {"devices": []}
+        with open(path) as inf:
+            controllerHardware = yaml.safe_load(inf)
 
-    userHardware = yaml.safe_load(
-        open('{0}/{1}.yaml'.format(config.labHardwareDirectory, config.labHardware), 'r'))
+    userHardware = {"devices": []}
+    lab_hardware_path = '{0}/{1}.yaml'.format(config.labHardwareDirectory, config.labHardware)
+    with open(lab_hardware_path) as inf:
+        userHardware = yaml.safe_load(inf)
 
     return {"devices": controllerHardware["devices"] + userHardware["devices"]}
 

--- a/backend/recipes/__init__.py
+++ b/backend/recipes/__init__.py
@@ -29,7 +29,8 @@ def getRecipeList():
     for f in files:
         if f.endswith('.json'):
             try:
-                recipeList.append(json.load(open(join(path, f))))
+                with open(join(path, f)) as inf:
+                    recipeList.append(json.load(inf))
             except json.JSONDecodeError:
                 logging.error("Error loading recipe file: {0}. File is not in proper JSON format".format(f))
         # This doesn't actually work yet because .4tv are not importable as modules


### PR DESCRIPTION
## TL;DR
Move file `open`-s  ti use a context manager to ensure the files are closed after use.

## What
What is affected by this PR?
- [ ] API
- [ ] GUI
- [ ] Hardware Integration
- [ ] OS/Deployment
- [ ] Documentation
- [X] Other (please describe in notes)

## Testing
How was this tested?
- [ ] Locally Virtualized
- [ ] Raspberry Pi
- [ ] With Hardware
- [X] Other (please describe in notes)

## Notes
Move file `open`-s  ti use a context manager to ensure the files are closed after use. More info on that here: https://docs.python.org/3/tutorial/inputoutput.html#reading-and-writing-files