### PR TITLE
Validate that hardware configs are acyclic, added tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Extra validation for hardware config files. Hardware components are now automatically sorted by dependencies to prevent them from loading out of order. (#269)
+
 ## [0.6.0]
 
 ### Added

--- a/backend/tests/devicelist_test.py
+++ b/backend/tests/devicelist_test.py
@@ -77,3 +77,14 @@ def test_accepts_simple_valid_config():
     res = validateConfiguration(devices)
     assert res is False
 
+
+def test_detects_missing_dependencies():
+    devices = [
+        {
+            "id": "1",
+            "dependencies": ["2"]
+        },
+    ]
+    with pytest.raises(Exception, match='Missing hardware configuration for dependency'):
+        res = validateConfiguration(devices)
+

--- a/backend/tests/devicelist_test.py
+++ b/backend/tests/devicelist_test.py
@@ -1,0 +1,79 @@
+from hardware.devicelist import validateConfiguration
+import pytest
+import yaml
+import hardware.core
+from unittest.mock import patch, MagicMock
+
+
+def test_detects_deplicate_ids():
+    devices = [
+        {
+            "id": "1"
+        },
+        {
+            "id": "1"
+        },
+    ]
+    with pytest.raises(Exception, match='Duplicate device id'):
+        res = validateConfiguration(devices)
+
+
+def test_detects_simple_circular_dependencies():
+    devices = [
+        {
+            "id": "1",
+            "dependencies": ["2"]
+        },
+        {
+            "id": "2",
+            "dependencies": ["1"]
+        },
+    ]
+    with pytest.raises(Exception, match='Circular dependency'):
+        res = validateConfiguration(devices)
+
+
+def test_detects_complex_circular_dependencies():
+    devices = [
+        {
+            "id": "4",
+            "dependencies": ["1"]
+        },
+        {
+            "id": "2",
+            "dependencies": ["3"]
+        },
+        {
+            "id": "1",
+            "dependencies": ["2"]
+        },
+        {
+            "id": "3",
+            "dependencies": ["4"]
+        },
+    ]
+    with pytest.raises(Exception, match='Circular dependency'):
+        res = validateConfiguration(devices)
+
+
+def test_accepts_simple_valid_config():
+    devices = [
+        {
+            "id": "1"
+        },
+        {
+            "id": "2",
+            "dependencies": ["1"]
+        },
+        {
+            "id": "3",
+            "dependencies": ["2"]
+        },
+        {
+            "id": "4",
+            "dependencies": ["3"]
+        },
+    ]
+    res = validateConfiguration(devices)
+    assert res is False
+

--- a/backend/tests/devicelist_test.py
+++ b/backend/tests/devicelist_test.py
@@ -1,4 +1,4 @@
-from hardware.devicelist import validateConfiguration
+from hardware.devicelist import validateConfiguration, sort_device_configs
 import pytest
 import yaml
 import hardware.core
@@ -87,4 +87,26 @@ def test_detects_missing_dependencies():
     ]
     with pytest.raises(Exception, match='Missing hardware configuration for dependency'):
         res = validateConfiguration(devices)
+
+
+def test_sort_device_configs_sorts_by_dependencies():
+    devices = [
+        {
+            "id": "1",
+            "dependencies": ["2"]
+        },
+        {
+            "id": "2",
+        },
+    ]
+
+    assert sort_device_configs(devices) == [
+        {
+            "id": "2",
+        },
+        {
+            "id": "1",
+            "dependencies": ["2"]
+        },
+    ]
 


### PR DESCRIPTION
## TL;DR
Quick summary/list of your change(s)
Adds validation to validateConfiguration that device configuration is acyclic, and adds tests for validateConfiguration.

## What
What is affected by this PR?
- [ ] API
- [ ] GUI
- [X] Hardware Integration
- [ ] OS/Deployment
- [ ] Documentation
- [ ] Other (please describe in notes)

## Testing
How was this tested?
- [ ] Locally Virtualized
- [X] Raspberry Pi
- [ ] With Hardware
- [ ] Other (please describe in notes)

## Notes
How was your day?