### PR TITLE
Make the hardware reload message appear on top of most other things

### DIFF
--- a/gui/src/pages/SettingsPage.scss
+++ b/gui/src/pages/SettingsPage.scss
@@ -24,6 +24,7 @@
   padding-bottom: 8px;
 }
 .hardware-reload-message {
+  z-index: 100;
   position: absolute;
   color: #fff;
   background-color: #000;


### PR DESCRIPTION
## TL;DR
What the subject says. When the message is long it appears below other UI elements and becomes unreadable. This PR fixes that.

## What
What is affected by this PR?
- [ ] API
- [x] GUI
- [ ] Hardware Integration
- [ ] OS/Deployment
- [ ] Documentation
- [ ] Other (please describe in notes)

## Testing
How was this tested?
- [x] Locally Virtualized
- [ ] Raspberry Pi
- [ ] With Hardware
- [ ] Other (please describe in notes)

## Notes
Pretty good honestly.