### PR TITLE
Fix log file not found

### DIFF
--- a/backend/util/logger.py
+++ b/backend/util/logger.py
@@ -73,7 +73,7 @@ class MultiprocessingLogger:
             os.makedirs(log_directory)
 
         rotating_file_handler = logging.handlers.RotatingFileHandler(
-                "{0}/microlab.log".format(config.microlabConfig.logDirectory),
+                "{0}/microlab.log".format(log_directory),
                 maxBytes=config.microlabConfig.logFileMaxBytes,
                 backupCount=config.microlabConfig.logFileBackupCount,
             )

--- a/backend/util/logger.py
+++ b/backend/util/logger.py
@@ -1,5 +1,6 @@
 import logging
 import logging.handlers
+import os
 import queue
 import sys
 import traceback
@@ -66,6 +67,10 @@ class MultiprocessingLogger:
         formatter = MultiLineFormatter(fmt="%(asctime)s %(name)-10s [%(levelname)s]: %(message)s")
 
         log_handlers = []
+        
+        log_directory = config.microlabConfig.logDirectory        
+        if not os.path.exists(log_directory):
+            os.makedirs(log_directory)
 
         rotating_file_handler = logging.handlers.RotatingFileHandler(
                 "{0}/microlab.log".format(config.microlabConfig.logDirectory),


### PR DESCRIPTION
## TL;DR
If the path specified in `logDirectory` isn't available the process will throw an exception and exit. While `RotatingFileHandler` creates the file if it is missing, it does not create the path. This PR makes sure it is created.

## What
What is affected by this PR?
- [X] API
- [ ] GUI
- [ ] Hardware Integration
- [ ] OS/Deployment
- [ ] Documentation
- [ ] Other (please describe in notes)

## Testing
How was this tested?
- [X] Locally Virtualized
- [ ] Raspberry Pi
- [ ] With Hardware
- [ ] Other (please describe in notes)

## Notes
I'm not sure if this should go somewhere else.