### PR TITLE
Test against supported python versions.

### DIFF
--- a/.github/workflows/backend_tests.yml
+++ b/.github/workflows/backend_tests.yml
@@ -6,15 +6,32 @@ on:
 
 jobs:
   backend_tests:
+    strategy:
+      matrix:
+        python-version:
+          - "3.13"
+          - "3.12"
+          - "3.11"
+          - "3.10"
+          - "3.9"
+
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./backend
     steps:
-      - uses: actions/checkout@v1
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
       - name: Install python dependencies
         run: |
           python -m pip install --upgrade pip
           sudo pip install -r requirements.txt
+
       - name: Run tests
         run: sudo pytest

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ sudo apt update
 sudo apt install python3 python3-pip python-virtualenv python3-virtualenv
 ```
 
+The backend is tested against CPython 3.9 to 3.13.
+
 Note: some versions of Linux have dropped support for Python2 and `python-virtualenv`.
 
 (for macOS)


### PR DESCRIPTION
## TL;DR
This PR adds the current supported [python versions](https://devguide.python.org/versions/#supported-versions) to the test CI. It also adds a note to the README.md about the supported python versions.

## What
What is affected by this PR?
- [ ] API
- [ ] GUI
- [ ] Hardware Integration
- [ ] OS/Deployment
- [ ] Documentation
- [X] Other (please describe in notes)

## Testing
How was this tested?
- [ ] Locally Virtualized
- [ ] Raspberry Pi
- [ ] With Hardware
- [X] Other (please describe in notes)


## Notes
What: CI
Testing: I tested by opening a dummy PR on my fork, all tests passed.