### PR TITLE
Adding caching and reload functionality for *localization*

### DIFF
--- a/backend/localization.py
+++ b/backend/localization.py
@@ -1,17 +1,46 @@
 import json
 import os
 
-BASE_PATH = os.path.join(os.path.dirname(__file__), "locales")
-DEFAULT_LANG = "en"
+BASE_PATH = os.path.join(os.path.dirname(__file__), 'locales')
+DEFAULT_LANG = 'en'
 
-def load_translation() -> dict:
-    lang_code="en"
-    lang_path = os.path.join(BASE_PATH, lang_code, "strings.json")
-    fallback_path = os.path.join(BASE_PATH, DEFAULT_LANG, "strings.json")
+def load_translation(lang_code: str = DEFAULT_LANG, reload: bool = False) -> dict[str, str]:
+    """
+    Load and cache translation JSON for a given language.
 
-    try:
-        with open(lang_path, 'r', encoding='utf-8') as f:
-            return json.load(f)
-    except FileNotFoundError:
-        with open(fallback_path, 'r', encoding='utf-8') as f:
-            return json.load(f)
+    Args:
+        lang_code: 2-letter language code (e.g. "en", "ua").
+        reload:    If True, forces re-reading from disk even if cached.
+
+    Returns:
+        A dict with English strings, updated with a desired language translation strings.
+
+    Raises:
+        FileNotFoundError: if neither lang_code nor DEFAULT_LANG file exists.
+    """
+    # init cache dict on function
+    if not hasattr(load_translation, '_cache'):
+        load_translation._cache = {}
+    cache = load_translation._cache
+
+    # if not reloading and we already have it, return cached
+    if not reload and lang_code in cache:
+        return cache[lang_code]
+
+    # build candidate file paths: default language, followed by a preferred language
+    language_codes = (DEFAULT_LANG,) if lang_code == DEFAULT_LANG else (DEFAULT_LANG, lang_code)
+
+    merged: dict[str, str] = {}
+    found_any = False
+    for code in language_codes:
+        path = os.path.join(BASE_PATH, code, 'strings.json')
+        if os.path.isfile(path):
+            with open(path, 'r', encoding='utf-8') as f:
+                merged.update(json.load(f))
+            found_any = True
+
+    if not found_any:
+        raise FileNotFoundError(f"No translation files found for '{lang_code}' or default '{DEFAULT_LANG}'.")
+
+    cache[lang_code] = merged
+    return merged


### PR DESCRIPTION
## TL;DR
Adding caching and reload functionality for localization.
Before the change every call to load_translation resulted in file read operation and JSON parsing.

## What
What is affected by this PR?
- [ ] API
- [ ] GUI
- [ ] Hardware Integration
- [ ] OS/Deployment
- [ ] Documentation
- [ ] Other (please describe in notes)

## Testing
How was this tested?
- [ ] Locally Virtualized
- [ ] Raspberry Pi
- [ ] With Hardware
- [ ] Other (please describe in notes)

## Notes
