### PR TITLE
Changing VENV folder name to canonical .venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,12 @@ pip3 install virtualenv
 ```
 
 Set up a Python virtual environment:
-virtualenv -p python3 --system-site-packages env
+virtualenv -p python3 --system-site-packages .venv
 
 ```bash
 cd backend
-virtualenv -p python3 --system-site-packages env
-source env/bin/activate
+virtualenv -p python3 --system-site-packages .venv
+source .venv/bin/activate
 (env) $ pip install -r requirements.txt
 ```
 

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -80,7 +80,7 @@ celerybeat-schedule
 
 # Environments
 .env
-.venv
+.venv/
 env/
 venv/
 ENV/

--- a/scripts/startFlask.sh
+++ b/scripts/startFlask.sh
@@ -10,7 +10,7 @@ fi
 # Deduct the backend directory (where we keep main.py & requirements.txt)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BACKEND_DIR="$SCRIPT_DIR/../backend"
-VENV_DIR="$BACKEND_DIR/env"
+VENV_DIR="$BACKEND_DIR/.venv"
 REQ_FILE="$BACKEND_DIR/requirements.txt"
 
 # Create/update venv only if missing or if requirements.txt is newer

--- a/scripts/startup-dev.sh
+++ b/scripts/startup-dev.sh
@@ -3,7 +3,7 @@
 # Probably this is redundant and wants to call the other scripts
 
 cd ../backend && \
-	virtualenv -p python3 --system-site-packages env && source env/bin/activate && \
+	virtualenv -p python3 --system-site-packages .venv && source .venv/bin/activate && \
 	pip install -r requirements.txt && \
 	export FLASK_APP=main.py && \
 	export FLASK_ENV=development && \

--- a/scripts/startup-prod.sh
+++ b/scripts/startup-prod.sh
@@ -3,7 +3,7 @@
 # Probably this is redundant and wants to call the other scripts
 
 cd ../backend && \
-	virtualenv -p python3 --system-site-packages env && source env/bin/activate && \
+	virtualenv -p python3 --system-site-packages .venv && source .venv/bin/activate && \
 	pip install -r requirements.txt && \
 	export FLASK_APP=main.py && \
 	export FLASK_ENV=production && \


### PR DESCRIPTION
## TL;DR
Addresses https://github.com/FourThievesVinegar/microlab-image/issues/3.  
Currently used "env" folder name is not canonical for Python's virtual environment.  
2 of 2  
1: https://github.com/FourThievesVinegar/microlab-image/pull/4  

## What
What is affected by this PR?
- [ ] API
- [ ] GUI
- [ ] Hardware Integration
- [X] OS/Deployment
- [X] Documentation
- [ ] Other (please describe in notes)

## Testing
How was this tested?
- [ ] Locally Virtualized
- [ ] Raspberry Pi
- [ ] With Hardware
- [ ] Other (please describe in notes)
